### PR TITLE
Addresses issue 46

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@12.6
+      - uses: DeLaGuardo/setup-clojure@13.0
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.6
+      - uses: DeLaGuardo/setup-clojure@13.0
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.6
+      - uses: DeLaGuardo/setup-clojure@13.0
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: DeLaGuardo/setup-clojure@12.6
+      - uses: DeLaGuardo/setup-clojure@13.0
         with:
           cli: latest
       - uses: actions/cache@v4

--- a/pbr.clj
+++ b/pbr.clj
@@ -28,4 +28,5 @@
                         :issue-management {:system "github" :url "https://github.com/pmonks/clj-spdx/issues"}}
          :codox        {:namespaces ['spdx.exceptions 'spdx.expressions 'spdx.licenses 'spdx.matching]
                         :metadata   {:doc/format :markdown}}
-         :test-deps    {'com.github.pmonks/urlocal {:mvn/version "RELEASE"}}))
+         :test-deps    {'com.github.pmonks/urlocal {:mvn/version "RELEASE"}
+                        'com.github.pmonks/rencg   {:mvn/version "RELEASE"}}))

--- a/pbr.clj
+++ b/pbr.clj
@@ -26,7 +26,7 @@
                                            :developer-connection "scm:git:ssh://git@github.com/pmonks/clj-spdx.git"
                                            :tag                  (tc/git-tag-or-hash)}
                         :issue-management {:system "github" :url "https://github.com/pmonks/clj-spdx/issues"}}
-         :codox        {:namespaces ['spdx.exceptions 'spdx.expressions 'spdx.licenses 'spdx.matching]
+         :codox        {:namespaces ['spdx.exceptions 'spdx.expressions 'spdx.licenses 'spdx.matching 'spdx.regexes]
                         :metadata   {:doc/format :markdown}}
          :test-deps    {'com.github.pmonks/urlocal {:mvn/version "RELEASE"}
                         'com.github.pmonks/rencg   {:mvn/version "RELEASE"}}))

--- a/src/spdx/exceptions.clj
+++ b/src/spdx/exceptions.clj
@@ -11,7 +11,8 @@
 (ns spdx.exceptions
   "Exception list functionality, primarily provided by `org.spdx.library.model.license.ListedLicenses`."
   (:require [spdx.impl.state   :as is]
-            [spdx.impl.mapping :as im]))
+            [spdx.impl.mapping :as im]
+            [spdx.impl.regexes :as ir]))
 
 (defn version
   "The version of the exception list (a `String` in major.minor format).
@@ -31,11 +32,12 @@
   [^String id]
   (im/listed-exception-id? id))
 
+(def ^:private addition-ref-re-d (delay (ir/re-concat #"(?i)\A" @ir/addition-ref-re-d #"\z")))
+
 (defn addition-ref?
-  "Is `id` an `AdditionRef`?  Returns `nil` if `id` is `nil`."
+  "Is `id` an `AdditionRef`?"
   [id]
-  (when id
-    (boolean (re-matches #"(DocumentRef-[\p{Alnum}-\.]+:)?AdditionRef-[\p{Alnum}-\.]+" id))))
+  (boolean (when id (re-matches @addition-ref-re-d id))))
 
 #_{:clj-kondo/ignore [:unused-binding {:exclude-destructured-keys-in-fn-args true}]}
 (defn id->info
@@ -54,14 +56,13 @@
            (im/exception->map opts))))
 
 (defn deprecated-id?
-  "Is `id` deprecated?  Returns `nil` if `id` is not in the SPDX license
+  "Is `id` deprecated?  Also returns `false` if `id` is not in the SPDX license
   exception list.
 
   See [this SPDX FAQ item](https://github.com/spdx/license-list-XML/blob/main/DOCS/faq.md#what-does-it-mean-when-a-license-id-is-deprecated)
   for details on what this means."
   [^String id]
-  (when (listed-id? id)
-    (boolean (:deprecated? (id->info id)))))
+  (boolean (when (listed-id? id) (:deprecated? (id->info id)))))
 
 (defn non-deprecated-ids
   "Returns the set of exception ids that identify current (non-deprecated)
@@ -80,7 +81,9 @@
   Note: this method may have a substantial performance cost."
   []
   (is/init!)
+  (ir/init!)
   ; This is slow mostly due to network I/O (file downloads), so we parallelise to reduce the elapsed time.
   ; Note: using embroidery's pmap* function has been found to be counter-productive here
   (doall (pmap id->info (ids)))
+  @addition-ref-re-d
   nil)

--- a/src/spdx/impl/regexes.clj
+++ b/src/spdx/impl/regexes.clj
@@ -1,0 +1,73 @@
+;
+; Copyright © 2024 Peter Monks
+;
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at https://mozilla.org/MPL/2.0/.
+;
+; SPDX-License-Identifier: MPL-2.0
+;
+
+(ns spdx.impl.regexes
+  "Regex related functionality.  This functionality is bespoke (it does not use
+  any logic from `Spdx-Java-Library`)."
+  (:require [clojure.string :as s]))
+
+(defn re-escape
+  "Escapes `s` (a `String`) for use in a regex. Returns a `String`."
+  [s]
+  (when s
+    (s/escape s {\< "\\<"
+                 \( "\\("
+                 \[ "\\["
+                 \{ "\\{"
+                 \\ "\\\\"
+                 \^ "\\^"
+                 \- "\\-"
+                 \= "\\="
+                 \$ "\\$"
+                 \! "\\!"
+                 \| "\\|"
+                 \] "\\]"
+                 \} "\\}"
+                 \) "\\)"
+                 \? "\\?"
+                 \* "\\*"
+                 \+ "\\+"
+                 \. "\\."
+                 \> "\\>"
+                 })))
+
+(defn re-concat
+  "Concatenate all of the given `Pattern`s or `String`s into a single `Pattern`."
+  [& res]
+  (re-pattern (s/join res)))
+
+(defn re-alternation
+  "Builds a regex group containing alternations of value of everything in
+  `coll` (a sequence of `String`s), returning a `String`.  Each value in `coll`
+  will be escaped.
+
+  When non-blank, the (optional) `group-name` parameter turns the group into a
+  named capturing group with that name."
+  ([coll] (re-alternation nil coll))
+  ([group-name coll]
+   (str "("
+        (when-not (s/blank? group-name) (str "?<" group-name ">"))
+        (s/join "|" (map re-escape coll))
+        ")")))
+
+(def license-ref-re-d  (delay #"(DocumentRef-(?<DocumentRef>[\p{Alnum}-\.]+):)?LicenseRef-(?<LicenseRef>[\p{Alnum}-\.]+)"))
+(def addition-ref-re-d (delay #"(DocumentRef-(?<AdditionDocumentRef>[\p{Alnum}-\.]+):)?AdditionRef-(?<AdditionRef>[\p{Alnum}-\.]+)"))
+
+(defn init!
+  "Initialises this namespace upon first call (and does nothing on subsequent
+  calls), returning `nil`. Consumers of this namespace are not required to call
+  this fn, as initialisation will occur implicitly anyway; it is provided to
+  allow explicit control of the cost of initialisation to callers who need it.
+
+  Note: this method may have a substantial performance cost."
+  []
+  @license-ref-re-d
+  @addition-ref-re-d
+  nil)

--- a/src/spdx/licenses.clj
+++ b/src/spdx/licenses.clj
@@ -11,7 +11,8 @@
 (ns spdx.licenses
   "License list functionality, primarily provided by `org.spdx.library.model.license.ListedLicenses`."
   (:require [spdx.impl.state   :as is]
-            [spdx.impl.mapping :as im]))
+            [spdx.impl.mapping :as im]
+            [spdx.impl.regexes :as ir]))
 
 (defn version
   "The version of the license list (a `String` in major.minor format).
@@ -31,11 +32,12 @@
   [^String id]
   (im/listed-license-id? id))
 
+(def ^:private license-ref-re-d (delay (ir/re-concat #"(?i)\A" @ir/license-ref-re-d #"\z")))
+
 (defn license-ref?
-  "Is `id` a `LicenseRef`?  Returns `nil` if `id` is `nil`."
+  "Is `id` a `LicenseRef`?"
   [id]
-  (when id
-    (boolean (re-matches #"(DocumentRef-[\p{Alnum}-\.]+:)?LicenseRef-[\p{Alnum}-\.]+" id))))
+  (boolean (when id (re-matches @license-ref-re-d id))))
 
 #_{:clj-kondo/ignore [:unused-binding {:exclude-destructured-keys-in-fn-args true}]}
 (defn id->info
@@ -54,13 +56,12 @@
            (im/license->map opts))))
 
 (defn deprecated-id?
-  "Is `id` deprecated?  Returns `nil` if `id` is not in the SPDX license list.
+  "Is `id` deprecated?  Also returns `false` if `id` is not in the SPDX license list.
 
   See [this SPDX FAQ item](https://github.com/spdx/license-list-XML/blob/main/DOCS/faq.md#what-does-it-mean-when-a-license-id-is-deprecated)
   for details on what this means."
   [^String id]
-  (when (listed-id? id)
-    (boolean (:deprecated? (id->info id)))))
+  (boolean (when (listed-id? id) (:deprecated? (id->info id)))))
 
 (defn non-deprecated-ids
   "Returns the set of license ids that identify current (non-deprecated)
@@ -71,13 +72,12 @@
                  set)))
 
 (defn osi-approved-id?
-  "Is `id` OSI Approved?  Returns `nil` if `id` is not in the SPDX license list.
+  "Is `id` OSI Approved?  Also returns `false` if `id` is not in the SPDX license list.
 
   See [this reference](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md)
   for details about what 'OSI Approved' means."
   [^String id]
-  (when (listed-id? id)
-    (boolean (:osi-approved? (id->info id)))))
+  (boolean (when (listed-id? id) (:osi-approved? (id->info id)))))
 
 (defn osi-approved-ids
   "Returns the set of SPDX license ids that identify OSI Approved licenses
@@ -91,13 +91,12 @@
                  set)))
 
 (defn fsf-libre-id?
-  "Is `id` FSF Libre?  Returns `nil` if `id` is not in the SPDX license list.
+  "Is `id` FSF Libre?  Also returns `false` if `id` is not in the SPDX license list.
 
   See [this reference](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md)
   for details about what 'FSF Libre' means."
   [^String id]
-  (when (listed-id? id)
-    (boolean (:fsf-libre? (id->info id)))))
+  (boolean (when (listed-id? id) (:fsf-libre? (id->info id)))))
 
 (defn fsf-libre-ids
   "Returns the set of SPDX license ids that identify FSF Libre licenses within
@@ -119,7 +118,9 @@
   Note: this method may have a substantial performance cost."
   []
   (is/init!)
+  (ir/init!)
   ; This is slow mostly due to network I/O (file downloads), so we parallelise to reduce the elapsed time.
   ; Note: using embroidery's pmap* function has been found to be counter-productive here
   (doall (pmap id->info (ids)))
+  @license-ref-re-d
   nil)

--- a/src/spdx/regexes.clj
+++ b/src/spdx/regexes.clj
@@ -1,0 +1,172 @@
+;
+; Copyright © 2024 Peter Monks
+;
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at https://mozilla.org/MPL/2.0/.
+;
+; SPDX-License-Identifier: MPL-2.0
+;
+
+(ns spdx.regexes
+  "Regex related functionality.  This functionality is bespoke (it does not use
+  any logic from `Spdx-Java-Library`)."
+  (:require [clojure.string    :as s]
+            [spdx.licenses     :as slic]
+            [spdx.exceptions   :as sexc]
+            [spdx.impl.regexes :as ir]))
+
+(defn- sort-by-count-desc
+  "Sorts `coll`, a sequence of `String`s, by the length of each entry, in
+  descending order (so longer values come first).  Returns `nil` if `coll` is
+  `nil` or `empty`."
+  [coll]
+  (when (seq coll)
+    (reverse (sort-by count coll))))
+
+#_{:clj-kondo/ignore [:unused-binding {:exclude-destructured-keys-in-fn-args true}]}
+(defn build-re
+  "Returns a regex (`Pattern`) that will match the given `ids`, or `nil` if
+  `ids` is `nil` or empty.  `ids` appear sorted longest to shortest in the regex,
+  so that more specific values are preferentially matched - this avoids
+  mismatches when one id is a subset of another id (e.g. `GPL-2.0` and
+  `GPL-2.0-or-later`).
+
+  `opts` are:
+
+  * `match-license-refs?` (default `false`) - controls whether LicenseRef
+    matching is also included in the regex
+  * `match-addition-refs?` (default `false`) - controls whether AdditionRef
+    matching is also included in the regex
+
+  Note:
+
+  * unlike other fns in this ns, this one returns a new `Pattern` object on
+    every invocation, even if the args are the same as a previous one"
+  ([ids] (build-re ids nil))
+  ([ids {:keys [match-license-refs? match-addition-refs?]
+         :or   {match-license-refs?  false
+                match-addition-refs? false}
+         :as   opts}]
+   (when (seq ids)
+     (ir/re-concat #"(?i)(\A|\b)"
+                   "(?<Identifier>"
+                   (when match-license-refs? (str @ir/license-ref-re-d "|"))
+                   (when match-addition-refs? (str @ir/addition-ref-re-d "|"))
+                   (s/join "|" (map ir/re-escape (sort-by-count-desc ids)))
+                   ")"
+                   #"(\b|\z)"))))
+
+(def ^:private ids-re-d (delay (build-re (concat (slic/ids) (sexc/ids)) {:match-license-refs? true :match-addition-refs? true})))
+
+(defn ids-re
+  "Returns a regex (`Pattern`) that matches any SPDX license identifier,
+  exception identifier, LicenseRef, or AdditionRef.  The regex provides these
+  named capturing groups:
+
+  * `Identifier` (always present) - matches the entire identifier
+  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
+    it contains one
+  * `LicenseRef` (optional) - matches the LicenseRef tag of a LicenseRef
+  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
+    AdditionRef, if it contains one
+  * `AdditionRef` (optional) - matches the AdditionRef tag of an AdditionRef
+
+  Notes:
+
+  * returns the same `Pattern` object on subsequent calls, so is efficient when
+    called many times"
+  []
+  @ids-re-d)
+
+(def ^:private license-ids-re-d (delay (build-re (slic/ids) {:match-license-refs? true})))
+
+(defn license-ids-re
+  "Returns a regex (`Pattern`) that matches any SPDX license identifier or
+  LicenseRef.  The regex provides these named capturing groups:
+
+  * `Identifier` (always present) - matches the entire identifier
+  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
+    it contains one
+  * `LicenseRef` (optional) - matches the LicenseRef tag of a LicenseRef
+
+  Notes:
+
+  * returns the same `Pattern` object on subsequent calls, so is efficient when
+    called many times"
+  []
+  @license-ids-re-d)
+
+(def ^:private exception-ids-re-d (delay (build-re (sexc/ids) {:match-addition-refs? true})))
+
+(defn exception-ids-re
+  "Returns a regex (`Pattern`) that matches any SPDX exception identifier or
+  AdditionRef.  The regex provides these named capturing groups:
+
+  * `Identifier` (always present) - matches the entire identifier
+  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
+    AdditionRef, if it contains one
+  * `AdditionRef` (optional) - matches the AdditionRef tag of an AdditionRef
+
+  Notes:
+
+  * returns the same `Pattern` object on subsequent calls, so is efficient when
+    called many times"
+  []
+  @exception-ids-re-d)
+
+(def ^:private license-ref-re-d (delay (ir/re-concat #"(?i)(\A|\b)"
+                                                     @ir/license-ref-re-d
+                                                     #"(\b|\z)")))
+
+(defn license-ref-re
+  "Returns a regex (`Pattern`) that matches any SPDX LicenseRef.  The regex
+  provides these named capturing groups:
+
+  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
+    it contains one
+  * `LicenseRef` (always present) - matches the LicenseRef tag of a LicenseRef
+
+  Notes:
+
+  * returns the same `Pattern` object on subsequent calls, so is efficient when
+    called many times"
+  []
+  @license-ref-re-d)
+
+(def ^:private addition-ref-re-d (delay (ir/re-concat #"(?i)(\A|\b)"
+                                                      @ir/addition-ref-re-d
+                                                      #"(\b|\z)")))
+
+(defn addition-ref-re
+ "Returns a regex (`Pattern`) that matches any SPDX AdditionRef.  The regex
+ provides these named capturing groups:
+
+  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
+    AdditionRef, if it contains one
+  * `AdditionRef` (always present) - matches the AdditionRef tag of an
+    AdditionRef
+
+  Notes:
+  * returns the same `Pattern` object on subsequent calls, so is efficient when
+    called many times"
+  []
+  @addition-ref-re-d)
+
+(defn init!
+  "Initialises this namespace upon first call (and does nothing on subsequent
+  calls), returning `nil`. Consumers of this namespace are not required to call
+  this fn, as initialisation will occur implicitly anyway; it is provided to
+  allow explicit control of the cost of initialisation to callers who need it.
+
+  Note: this method may have a substantial performance cost."
+  []
+  (slic/init!)
+  (sexc/init!)
+  (ir/init!)
+  @ids-re-d
+  @license-ids-re-d
+  @exception-ids-re-d
+  @license-ref-re-d
+  @addition-ref-re-d
+  nil)

--- a/src/spdx/regexes.clj
+++ b/src/spdx/regexes.clj
@@ -26,23 +26,23 @@
 
 #_{:clj-kondo/ignore [:unused-binding {:exclude-destructured-keys-in-fn-args true}]}
 (defn build-re
-  "Returns a regex (`Pattern`) that will match the given `ids`, or `nil` if
-  `ids` is `nil` or empty.  `ids` appear sorted longest to shortest in the regex,
-  so that more specific values are preferentially matched - this avoids
-  mismatches when one id is a subset of another id (e.g. `GPL-2.0` and
-  `GPL-2.0-or-later`).
+  "Returns a regex (`Pattern`) that will match the given `ids` (a sequence of
+  `String`s), or `nil` if `ids` is `nil` or empty.  `ids` appear in the regex
+  sorted from longest to shortest, so that more specific values are
+  preferentially matched first - this avoids mismatches when one id is a subset
+  of another id (e.g. `GPL-2.0` and `GPL-2.0-or-later`).
 
   `opts` are:
 
-  * `match-license-refs?` (default `false`) - controls whether LicenseRef
+  * `match-license-refs?` (default `false`) - controls whether `LicenseRef`
     matching is also included in the regex
-  * `match-addition-refs?` (default `false`) - controls whether AdditionRef
+  * `match-addition-refs?` (default `false`) - controls whether `AdditionRef`
     matching is also included in the regex
 
   Note:
 
-  * unlike other fns in this ns, this one returns a new `Pattern` object on
-    every invocation, even if the args are the same as a previous one"
+  * _unlike_ other fns in this ns, this one returns a new `Pattern` object on
+    every invocation, even if the arguments are the same"
   ([ids] (build-re ids nil))
   ([ids {:keys [match-license-refs? match-addition-refs?]
          :or   {match-license-refs?  false
@@ -61,16 +61,18 @@
 
 (defn ids-re
   "Returns a regex (`Pattern`) that matches any SPDX license identifier,
-  exception identifier, LicenseRef, or AdditionRef.  The regex provides these
-  named capturing groups:
+  exception identifier, `LicenseRef`, or `AdditionRef`.  The regex provides
+  these named capturing groups:
 
-  * `Identifier` (always present) - matches the entire identifier
-  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
-    it contains one
-  * `LicenseRef` (optional) - matches the LicenseRef tag of a LicenseRef
-  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
-    AdditionRef, if it contains one
-  * `AdditionRef` (optional) - matches the AdditionRef tag of an AdditionRef
+  * `Identifier` (always present) - captures the entire identifier, `LicenseRef`
+    or `AdditionRef`
+  * `DocumentRef` (optional) - captures the `DocumentRef` tag of a `LicenseRef`,
+    if it contains one
+  * `LicenseRef` (optional) - captures the `LicenseRef` tag of a `LicenseRef`
+  * `AdditionDocumentRef` (optional) - captures the `DocumentRef` tag of an
+    `AdditionRef`, if it contains one
+  * `AdditionRef` (optional) - captures the `AdditionRef` tag of an
+    `AdditionRef`
 
   Notes:
 
@@ -83,12 +85,13 @@
 
 (defn license-ids-re
   "Returns a regex (`Pattern`) that matches any SPDX license identifier or
-  LicenseRef.  The regex provides these named capturing groups:
+  `LicenseRef`.  The regex provides these named capturing groups:
 
-  * `Identifier` (always present) - matches the entire identifier
-  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
-    it contains one
-  * `LicenseRef` (optional) - matches the LicenseRef tag of a LicenseRef
+  * `Identifier` (always present) - captures the entire identifier or
+    `LicenseRef`
+  * `DocumentRef` (optional) - captures the `DocumentRef` tag of a `LicenseRef`,
+    if it contains one
+  * `LicenseRef` (optional) - captures the `LicenseRef` tag of a `LicenseRef`
 
   Notes:
 
@@ -103,10 +106,11 @@
   "Returns a regex (`Pattern`) that matches any SPDX exception identifier or
   AdditionRef.  The regex provides these named capturing groups:
 
-  * `Identifier` (always present) - matches the entire identifier
-  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
-    AdditionRef, if it contains one
-  * `AdditionRef` (optional) - matches the AdditionRef tag of an AdditionRef
+  * `Identifier` (always present) - captures the entire identifier or
+    `AdditionRef`
+  * `AdditionDocumentRef` (optional) - captures the `DocumentRef` tag of an
+    `AdditionRef`, if it contains one
+  * `AdditionRef` (optional) - captures the `AdditionRef` tag of an `AdditionRef`
 
   Notes:
 
@@ -120,12 +124,13 @@
                                                      #"(\b|\z)")))
 
 (defn license-ref-re
-  "Returns a regex (`Pattern`) that matches any SPDX LicenseRef.  The regex
+  "Returns a regex (`Pattern`) that matches any SPDX `LicenseRef`.  The regex
   provides these named capturing groups:
 
-  * `DocumentRef` (optional) - matches the DocumentRef tag of a LicenseRef, if
-    it contains one
-  * `LicenseRef` (always present) - matches the LicenseRef tag of a LicenseRef
+  * `DocumentRef` (optional) - captures the `DocumentRef` tag of a `LicenseRef`,
+    if it contains one
+  * `LicenseRef` (always present) - captures the `LicenseRef` tag of a
+    `LicenseRef`
 
   Notes:
 
@@ -139,15 +144,16 @@
                                                       #"(\b|\z)")))
 
 (defn addition-ref-re
- "Returns a regex (`Pattern`) that matches any SPDX AdditionRef.  The regex
+ "Returns a regex (`Pattern`) that matches any SPDX `AdditionRef`.  The regex
  provides these named capturing groups:
 
-  * `AdditionDocumentRef` (optional) - matches the DocumentRef tag of an
-    AdditionRef, if it contains one
-  * `AdditionRef` (always present) - matches the AdditionRef tag of an
-    AdditionRef
+  * `AdditionDocumentRef` (optional) - captures the `DocumentRef` tag of an
+    `AdditionRef`, if it contains one
+  * `AdditionRef` (always present) - captures the `AdditionRef` tag of an
+    `AdditionRef`
 
   Notes:
+
   * returns the same `Pattern` object on subsequent calls, so is efficient when
     called many times"
   []

--- a/test/spdx/aa_init_test.clj
+++ b/test/spdx/aa_init_test.clj
@@ -11,21 +11,29 @@
 ; Naming is a hack to get it to run first
 (ns spdx.aa-init-test
   (:require [clojure.test      :refer [deftest testing is]]
-            [spdx.test-utils]      ; Unused, but we force it to run first
+            [spdx.test-utils]      ; Unused here, but we force it to run first
             [spdx.impl.state   :as sis]
             [spdx.impl.mapping :as sim]
             [spdx.licenses     :as sl]
             [spdx.exceptions   :as se]
-            [spdx.expressions  :as sexp]))
+            [spdx.expressions  :as sexp]
+            [spdx.regexes      :as sr]))
 
 ; clojure.core/time, but with improved output
 (defmacro my-time
   "Evaluates expr and prints the time it took.  Returns the value of expr."
   [expr]
   `(let [start# (. System (nanoTime))
-         ret# ~expr]
+         ret#   ~expr]
      (println (format "%.3f secs" (/ (double (- (. System (nanoTime)) start#)) 1000000000.0)))
      ret#))
+
+(defmacro elapsed-time
+  "Evaluates expr and returns the time it took. Value of expr is thrown away."
+  [expr]
+  `(let [start# (. System (nanoTime))]
+     ~expr
+     (/ (double (- (. System (nanoTime)) start#)) 1000000000.0)))
 
 ; This has to be a single test to ensure ordering
 (deftest init!-tests
@@ -34,17 +42,18 @@
     (is (nil? (sim/init!))))
   (testing "spdx.licenses/init!"
     (print "spdx.licenses/init! took: ") (flush)
-    (is (nil? (my-time (sl/init!))))   ; Note: this call is slow (it can take > 1 minute on my laptop), as it forces full initialisation of the underlying Java library
-    (let [elapsed-time (parse-double (re-find #"[\d\.]+" (with-out-str (my-time (sl/init!)))))]   ; Note: this regex isn't quite correct, since it will also match things like 1.2.3. (time) doesn't return messages containing that however.
-      (is (< elapsed-time 500.0))))   ; This call should be a LOT less than 0.5 second, on basically any computer
+    (is (nil? (my-time (sl/init!))))           ; This first call is slow (it can take > 1 minute on my laptop), as it forces initialisation of some of the underlying Java library
+    (is (< (elapsed-time (sl/init!)) 500.0)))  ; This second call should be a LOT less than 0.5 second, on basically any computer
   (testing "spdx.exceptions/init!"
     (print "spdx.exceptions/init! took: ") (flush)
-    (is (nil? (my-time (se/init!))))
-    (let [elapsed-time (parse-double (re-find #"[\d\.]+" (with-out-str (my-time (se/init!)))))]   ; Note: this regex isn't quite correct, since it will also match things like 1.2.3. (time) doesn't return messages containing that however.
-      (is (< elapsed-time 500.0))))   ; This call should be a LOT less than 0.5 second, on basically any computer
+    (is (nil? (my-time (se/init!))))           ; This first call is slow (albeit nowhere near as slow as sl/init), as it forces initialisation of some of the underlying Java library
+    (is (< (elapsed-time (se/init!)) 500.0)))  ; This second call should be a LOT less than 0.5 second, on basically any computer
   (testing "spdx.expressions/init!"
     (print "spdx.expressions/init! took: ") (flush)
     (is (nil? (my-time (sexp/init!))))
-    (let [elapsed-time (parse-double (re-find #"[\d\.]+" (with-out-str (my-time (sexp/init!)))))]   ; Note: this regex isn't quite correct, since it will also match things like 1.2.3. (time) doesn't return messages containing that however.
-      (is (< elapsed-time 500.0)))   ; This call should be a LOT less than 0.5 second, on basically any computer
-    (println (str "\nℹ️ Using SPDX license list v" (sl/version))) (flush)))
+    (is (< (elapsed-time (sexp/init!)) 500.0)))  ; This second call should be a LOT less than 0.5 second, on basically any computer
+  (testing "spdx.regexes/init!"
+    (print "spdx.regexes/init! took: ") (flush)
+    (is (nil? (my-time (sr/init!))))
+    (is (< (elapsed-time (se/init!)) 500.0)))  ; This second call should be a LOT less than 0.5 second, on basically any computer
+  (println (str "\nℹ️ Using SPDX license list v" (sl/version))) (flush))

--- a/test/spdx/exceptions_test.clj
+++ b/test/spdx/exceptions_test.clj
@@ -28,21 +28,25 @@
 
 (deftest listed-id?-tests
   (testing "Common ids are present"
-    (is (listed-id? "Classpath-exception-2.0"))
-    (is (listed-id? "GPL-3.0-linking-exception"))
-    (is (listed-id? "Linux-syscall-note")))
+    (is (true? (listed-id? "Classpath-exception-2.0")))
+    (is (true? (listed-id? "GPL-3.0-linking-exception")))
+    (is (true? (listed-id? "Linux-syscall-note"))))
   (testing "Made up ids are not present"
-    (is (not (listed-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL")))))
+    (is (false? (listed-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL")))))
 
 (deftest addition-ref?-tests
-  (testing "Invalid AdditionRefs return nil"
-    (is (not (addition-ref? nil)))
-    (is (not (addition-ref? "")))
-    (is (not (addition-ref? "INVALID-ADDITION-REF"))))
+  (testing "Invalid AdditionRefs return false"
+    (is (false? (addition-ref? nil)))
+    (is (false? (addition-ref? "")))
+    (is (false? (addition-ref? "INVALID-ADDITION-REF")))
+    (is (false? (addition-ref? " AdditionRef-foo")))                   ; Leading whitespace
+    (is (false? (addition-ref? "AdditionRef-foo ")))                   ; Trailing whitespace
+    (is (false? (addition-ref? "AdditionRef-%#^*")))                   ; Invalid characters in AdditionRef tag
+    (is (false? (addition-ref? "DocumentRef-%#^*:AdditionRef-bar"))))  ; Invalid characters in DocumentRef tag
   (testing "Valid AdditionRefs"
-    (is (addition-ref? "AdditionRef-foo"))
-    (is (addition-ref? "DocumentRef-foo:AdditionRef-bar"))
-    (is (addition-ref? "DocumentRef-0123456789-.abcdefgABCDEFG:AdditionRef-0123456789-.abcdefgABCDEFG"))))
+    (is (true? (addition-ref? "AdditionRef-foo")))
+    (is (true? (addition-ref? "DocumentRef-foo:AdditionRef-bar")))
+    (is (true? (addition-ref? "DocumentRef-0123456789-.abcdefgABCDEFG:AdditionRef-0123456789-.abcdefgABCDEFG")))))
 
 (deftest id->info-tests
   (testing "Invalid ids return nil"
@@ -63,14 +67,14 @@
   (testing "Select keys have expected values"
     (let [info (id->info "Classpath-exception-2.0")]
       (is (=           (:name        info) "Classpath exception 2.0"))
-      (is (not         (:deprecated? info)))
+      (is (nil?        (:deprecated? info)))
       (is (pos? (count (:see-also    info)))))))
 
 (deftest deprecated-id?-tests
   (testing "Invalid ids return nil"
-    (is (nil? (deprecated-id? nil)))
-    (is (nil? (deprecated-id? "")))
-    (is (nil? (deprecated-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
+    (is (false? (deprecated-id? nil)))
+    (is (false? (deprecated-id? "")))
+    (is (false? (deprecated-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
   (testing "Deprecated ids"
     (is (true? (deprecated-id? "Nokia-Qt-exception-1.1"))))
   (testing "Non-deprecated ids"

--- a/test/spdx/licenses_test.clj
+++ b/test/spdx/licenses_test.clj
@@ -27,24 +27,28 @@
     (is (instance? java.util.Set (ids)))))
 
 (deftest listed-id?-tests
-  (testing "Invalid ids return nil"
-    (is (not (listed-id? nil)))
-    (is (not (listed-id? "")))
-    (is (not (listed-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
+  (testing "Invalid ids return false"
+    (is (false? (listed-id? nil)))
+    (is (false? (listed-id? "")))
+    (is (false? (listed-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
   (testing "Common ids are present"
-    (is (listed-id? "Apache-2.0"))
-    (is (listed-id? "GPL-3.0"))
-    (is (listed-id? "CC-BY-4.0"))))
+    (is (true? (listed-id? "Apache-2.0")))
+    (is (true? (listed-id? "GPL-3.0")))
+    (is (true? (listed-id? "CC-BY-4.0")))))
 
 (deftest license-ref?-tests
-  (testing "Invalid LicenseRefs return nil"
-    (is (not (license-ref? nil)))
-    (is (not (license-ref? "")))
-    (is (not (license-ref? "INVALID-LICENSE-REF"))))
+  (testing "Invalid LicenseRefs return false"
+    (is (false? (license-ref? nil)))
+    (is (false? (license-ref? "")))
+    (is (false? (license-ref? "INVALID-LICENSE-REF")))
+    (is (false? (license-ref? " LicenseRef-foo")))                   ; Leading whitespace
+    (is (false? (license-ref? "LicenseRef-foo ")))                   ; Trailing whitespace
+    (is (false? (license-ref? "LicenseRef-%#^*")))                   ; Invalid characters in LicenseRef tag
+    (is (false? (license-ref? "DocumentRef-%#^*:LicenseRef-bar"))))  ; Invalid characters in DocumentRef tag
   (testing "Valid LicenseRefs"
-    (is (license-ref? "LicenseRef-foo"))
-    (is (license-ref? "DocumentRef-foo:LicenseRef-bar"))
-    (is (license-ref? "DocumentRef-0123456789-.abcdefgABCDEFG:LicenseRef-0123456789-.abcdefgABCDEFG"))))
+    (is (true? (license-ref? "LicenseRef-foo")))
+    (is (true? (license-ref? "DocumentRef-foo:LicenseRef-bar")))
+    (is (true? (license-ref? "DocumentRef-0123456789-.abcdefgABCDEFG:LicenseRef-0123456789-.abcdefgABCDEFG")))))
 
 (deftest id->info-tests
   (testing "Invalid ids return nil"
@@ -65,28 +69,28 @@
   (testing "Select keys have expected values"
     (let [info (id->info "Apache-2.0")]
       (is (=           (:name          info) "Apache License 2.0"))
-      (is              (:osi-approved? info))
-      (is              (:fsf-libre?    info))
+      (is (true?       (:osi-approved? info)))
+      (is (true?       (:fsf-libre?    info)))
       (is (pos? (count (:cross-refs    info)))))))
 
 (deftest deprecated-id?-tests
-  (testing "Invalid ids return nil"
-    (is (nil? (deprecated-id? nil)))
-    (is (nil? (deprecated-id? "")))
-    (is (nil? (deprecated-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
+  (testing "Invalid ids return false"
+    (is (false? (deprecated-id? nil)))
+    (is (false? (deprecated-id? "")))
+    (is (false? (deprecated-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
   (testing "Deprecated ids"
-    (is (deprecated-id? "GPL-2.0"))
-    (is (deprecated-id? "Nunit"))
-    (is (deprecated-id? "wxWindows")))
+    (is (true? (deprecated-id? "GPL-2.0")))
+    (is (true? (deprecated-id? "Nunit")))
+    (is (true? (deprecated-id? "wxWindows"))))
   (testing "Non-deprecated ids"
-    (is (not (deprecated-id? "GPL-2.0-only")))
-    (is (not (deprecated-id? "GPL-2.0-or-later")))
-    (is (not (deprecated-id? "Sendmail")))
-    (is (not (deprecated-id? "SSH-OpenSSH")))
-    (is (not (deprecated-id? "Latex2e")))
-    (is (not (deprecated-id? "MIT")))
-    (is (not (deprecated-id? "gnuplot")))
-    (is (not (deprecated-id? "OLDAP-2.2.2")))))
+    (is (false? (deprecated-id? "GPL-2.0-only")))
+    (is (false? (deprecated-id? "GPL-2.0-or-later")))
+    (is (false? (deprecated-id? "Sendmail")))
+    (is (false? (deprecated-id? "SSH-OpenSSH")))
+    (is (false? (deprecated-id? "Latex2e")))
+    (is (false? (deprecated-id? "MIT")))
+    (is (false? (deprecated-id? "gnuplot")))
+    (is (false? (deprecated-id? "OLDAP-2.2.2")))))
 
 (deftest non-deprecated-ids-tests
   (testing "We have some non-deprecated-ids"
@@ -95,24 +99,24 @@
     (is (instance? java.util.Set (non-deprecated-ids)))))
 
 (deftest osi-approved-id?-tests
-  (testing "Invalid ids return nil"
-    (is (nil? (osi-approved-id? nil)))
-    (is (nil? (osi-approved-id? "")))
-    (is (nil? (osi-approved-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
+  (testing "Invalid ids return false"
+    (is (false? (osi-approved-id? nil)))
+    (is (false? (osi-approved-id? "")))
+    (is (false? (osi-approved-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
   (testing "OSI approved ids"
-    (is (osi-approved-id? "Apache-2.0"))
-    (is (osi-approved-id? "GPL-3.0"))
-    (is (osi-approved-id? "GPL-3.0-only"))
-    (is (osi-approved-id? "GPL-3.0-or-later")))
+    (is (true? (osi-approved-id? "Apache-2.0")))
+    (is (true? (osi-approved-id? "GPL-3.0")))
+    (is (true? (osi-approved-id? "GPL-3.0-only")))
+    (is (true? (osi-approved-id? "GPL-3.0-or-later"))))
   (testing "Non-OSI approved ids"
-    (is (not (osi-approved-id? "BSD-3-Clause-No-Military-License")))
-    (is (not (osi-approved-id? "WTFPL")))
-    (is (not (osi-approved-id? "CC-BY-SA-4.0")))
-    (is (not (osi-approved-id? "BSD-4-Clause")))
-    (is (not (osi-approved-id? "JSON")))
-    (is (not (osi-approved-id? "X11")))
-    (is (not (osi-approved-id? "Beerware")))
-    (is (not (osi-approved-id? "Hippocratic-2.1")))))
+    (is (false? (osi-approved-id? "BSD-3-Clause-No-Military-License")))
+    (is (false? (osi-approved-id? "WTFPL")))
+    (is (false? (osi-approved-id? "CC-BY-SA-4.0")))
+    (is (false? (osi-approved-id? "BSD-4-Clause")))
+    (is (false? (osi-approved-id? "JSON")))
+    (is (false? (osi-approved-id? "X11")))
+    (is (false? (osi-approved-id? "Beerware")))
+    (is (false? (osi-approved-id? "Hippocratic-2.1")))))
 
 (deftest osi-approved-ids-tests
   (testing "We have some osi-approved-ids"
@@ -121,25 +125,25 @@
     (is (instance? java.util.Set (osi-approved-ids)))))
 
 (deftest fsf-libre-id?-tests
-  (testing "Invalid ids return nil"
-    (is (nil? (fsf-libre-id? nil)))
-    (is (nil? (fsf-libre-id? "")))
-    (is (nil? (fsf-libre-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
+  (testing "Invalid ids return false"
+    (is (false? (fsf-libre-id? nil)))
+    (is (false? (fsf-libre-id? "")))
+    (is (false? (fsf-libre-id? "INVALID-ID-WHICH-DOES-NOT-EXIST-IN-SPDX-AND-NEVER-WILL"))))
   (testing "FSF Libre ids"
-    (is (fsf-libre-id? "Intel"))
-    (is (fsf-libre-id? "Unlicense"))
-    (is (fsf-libre-id? "Apache-1.0"))
-    (is (fsf-libre-id? "CDDL-1.0")))
+    (is (true? (fsf-libre-id? "Intel")))
+    (is (true? (fsf-libre-id? "Unlicense")))
+    (is (true? (fsf-libre-id? "Apache-1.0")))
+    (is (true? (fsf-libre-id? "CDDL-1.0"))))
   (testing "Non-FSF-Libre ids"
     ; Note: the SPDX license list tends to leave this field out rather than populate it with false, hence we don't test with false?
-    (is (not (fsf-libre-id? "GPL-1.0")))
-    (is (not (fsf-libre-id? "MIT-0")))
-    (is (not (fsf-libre-id? "PostgreSQL")))
-    (is (not (fsf-libre-id? "Glide")))
-    (is (not (fsf-libre-id? "OML")))
-    (is (not (fsf-libre-id? "Libpng")))
-    (is (not (fsf-libre-id? "MPL-1.0")))
-    (is (not (fsf-libre-id? "Xerox")))))
+    (is (false? (fsf-libre-id? "GPL-1.0")))
+    (is (false? (fsf-libre-id? "MIT-0")))
+    (is (false? (fsf-libre-id? "PostgreSQL")))
+    (is (false? (fsf-libre-id? "Glide")))
+    (is (false? (fsf-libre-id? "OML")))
+    (is (false? (fsf-libre-id? "Libpng")))
+    (is (false? (fsf-libre-id? "MPL-1.0")))
+    (is (false? (fsf-libre-id? "Xerox")))))
 
 (deftest fsf-libre-ids-ids-tests
   (testing "We have some fsf-libre-ids"

--- a/test/spdx/matching_test.clj
+++ b/test/spdx/matching_test.clj
@@ -50,7 +50,7 @@
 
 
 ; 3rd party software with single licenses
-(def clj-spdx-license                (delay (slurp (http-get "https://raw.githubusercontent.com/pmonks/clj-spdx/main/LICENSE"))))                 ; Apache-2.0
+(def clj-spdx-license                (delay (slurp (http-get "https://raw.githubusercontent.com/pmonks/clj-spdx/main/LICENSE"))))                 ; MPL-2.0
 (def commonmark-java-license         (delay (slurp (http-get "https://raw.githubusercontent.com/commonmark/commonmark-java/main/LICENSE.txt"))))  ; BSD-2-Clause
 
 ; Dual license texts
@@ -106,7 +106,7 @@
 ;    (is (true?  (text-is-license? @mit-text            "MIT")))              ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/234 (fixed in 2.0)
     )
   (testing "Exactly matching 3rd party license texts"
-    (is (true?  (text-is-license? @clj-spdx-license        "Apache-2.0")))
+    (is (true?  (text-is-license? @clj-spdx-license        "MPL-2.0")))
     (is (true?  (text-is-license? @commonmark-java-license "BSD-2-Clause")))))
 
 (deftest text-is-exception?-tests
@@ -164,7 +164,7 @@
 ;    (is (true?  (text-contains-license? @mit-text            "MIT")))              ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/234 (fixed in 2.0)
     )
   (testing "3rd party license text contains license"
-    (is (true?  (text-contains-license? @clj-spdx-license        "Apache-2.0")))
+    (is (true?  (text-contains-license? @clj-spdx-license        "MPL-2.0")))
     (is (true?  (text-contains-license? @commonmark-java-license "BSD-2-Clause"))))
   (testing "Larger texts with junk characters contain licenses"
     (is (true?  (text-contains-license? (str "ABCD\n" @apache-20-text          "\nEFGH") "Apache-2.0")))
@@ -172,7 +172,7 @@
 ;    (is (true?  (text-contains-license? (str "ABCD\n" @cc-by-40-text           "\nEFGH") "CC-BY-4.0")))  ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/233
     (is (true?  (text-contains-license? (str "ABCD\n" @mpl-20-text             "\nEFGH") "MPL-2.0")))
 ;    (is (true?  (text-contains-license? (str "ABCD\n" @mit-text                "\nEFGH") "MIT")))        ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/234 (fixed in 2.0)
-    (is (true?  (text-contains-license? (str "ABCD\n" @clj-spdx-license        "\nEFGH") "Apache-2.0")))
+    (is (true?  (text-contains-license? (str "ABCD\n" @clj-spdx-license        "\nEFGH") "MPL-2.0")))
     (is (true?  (text-contains-license? @jffi-text                                       "Apache-2.0")))
     (is (true?  (text-contains-license? @jffi-text                                       "LGPL-3.0-or-later")))
     (is (true?  (text-contains-license? (str "ABCD\n" @commonmark-java-license "\nEFGH") "BSD-2-Clause")))))
@@ -205,7 +205,7 @@
     (is (false? (texts-equivalent-licenses? nil @clj-spdx-license)))
     (is (false? (texts-equivalent-licenses? "" @clj-spdx-license))))
   (testing "Equivalent license texts"
-    (is (true?  (texts-equivalent-licenses? @apache-20-text @clj-spdx-license)))))
+    (is (true?  (texts-equivalent-licenses? @mpl-20-text @clj-spdx-license)))))
 
 (deftest texts-equivalent-exceptions?-tests
   (testing "nil, empty string"
@@ -257,7 +257,7 @@
 ;    (is (= (licenses-within-text @mit-text             #{"MIT"})))             ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/234 (fixed in 2.0)
     )
   (testing "Matching 3rd party license texts that only contain a single license"
-    (is (= (licenses-within-text @clj-spdx-license)        #{"Apache-2.0"}))
+    (is (= (licenses-within-text @clj-spdx-license)        #{"MPL-2.0-no-copyleft-exception" "MPL-2.0"}))
     (is (= (licenses-within-text @commonmark-java-license) #{"BSD-2-Clause"})))
   (testing "Matching larger texts with junk characters and a single license"
     (is (= (licenses-within-text (str "ABCD\n" @apache-20-text          "\nEFGH")) #{"Apache-2.0"}))
@@ -266,7 +266,7 @@
     (is (= (licenses-within-text (str "ABCD\n" @mpl-20-text             "\nEFGH")) #{"MPL-2.0-no-copyleft-exception" "MPL-2.0"}))
 ;    (is (= (licenses-within-text (str "ABCD\n" @mit-text                "\nEFGH")) #{"MIT"}))        ; Failing due to https://github.com/spdx/Spdx-Java-Library/issues/234 (fixed in 2.0)
     (is (= (licenses-within-text (str "ABCD\n" @wtfpl-text              "\nEFGH")) #{"WTFPL"}))
-    (is (= (licenses-within-text (str "ABCD\n" @clj-spdx-license        "\nEFGH")) #{"Apache-2.0"}))
+    (is (= (licenses-within-text (str "ABCD\n" @clj-spdx-license        "\nEFGH")) #{"MPL-2.0-no-copyleft-exception" "MPL-2.0"}))
     (is (= (licenses-within-text (str "ABCD\n" @commonmark-java-license "\nEFGH")) #{"BSD-2-Clause"})))
   (testing "Matching larger texts with multiple licenses and (optionally) other text (e.g. exceptions) that shouldn't match"
     (is (= (licenses-within-text @apache-20-gpl-30-text)              #{"Apache-2.0" "GPL-3.0-only" "GPL-3.0+" "GPL-3.0-or-later" "GPL-3.0"}))

--- a/test/spdx/regexes_test.clj
+++ b/test/spdx/regexes_test.clj
@@ -1,0 +1,204 @@
+;
+; Copyright © 2023 Peter Monks
+;
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at https://mozilla.org/MPL/2.0/.
+;
+; SPDX-License-Identifier: MPL-2.0
+;
+
+(ns spdx.regexes-test
+  (:require [clojure.test    :refer [deftest testing is]]
+            [rencg.api       :as rencg]
+            [spdx.test-utils]      ; Unused here, but we force it to run first
+            [spdx.regexes    :refer [build-re ids-re license-ids-re exception-ids-re license-ref-re addition-ref-re]]))
+
+(deftest build-re-tests
+  (testing "Basic tests"
+    (is (nil? (build-re nil)))
+    (is (nil? (build-re nil {:match-license-refs? true})))
+    (is (nil? (build-re nil {:match-addition-refs? true})))
+    (is (nil? (build-re nil {:match-license-refs? true :match-addition-refs? true})))
+    (is (instance? java.util.regex.Pattern (build-re ["Apache-2.0"]))))
+  (let [apache-20-re (build-re ["Apache-2.0"])]
+    (testing "matches"
+      (is (not (nil? (re-matches apache-20-re "Apache-2.0")))))
+    (testing "non-matches"
+      (is (nil? (re-matches apache-20-re "")))
+      (is (nil? (re-matches apache-20-re "foobar")))
+      (is (nil? (re-matches apache-20-re " Apache-2.0 ")))
+      (is (nil? (re-matches apache-20-re "Apache-200")))
+      (is (nil? (re-matches apache-20-re "GPL-2.0")))
+      (is (nil? (re-matches apache-20-re "Apache-1.1")))
+      (is (nil? (re-matches apache-20-re "Apache-2.0 GPL-2.0")))
+      (is (nil? (re-matches apache-20-re "LicenseRef-foo-bar"))))
+    (testing "finds"
+      (is (not (nil? (re-find apache-20-re "Apache-2.0"))))
+      (is (not (nil? (re-find apache-20-re " Apache-2.0 "))))
+      (is (not (nil? (re-find apache-20-re "foo Apache-2.0"))))
+      (is (not (nil? (re-find apache-20-re "Apache-2.0 bar"))))
+      (is (not (nil? (re-find apache-20-re "foo Apache-2.0 bar"))))
+      (is (not (nil? (re-find apache-20-re "foo;Apache-2.0;bar"))))
+      (is (not (nil? (re-find apache-20-re "Apache-1.1 Apache-2.0 GPL-2.0")))))
+    (testing "non-finds"
+      (is (nil? (re-find apache-20-re "")))
+      (is (nil? (re-find apache-20-re "foobar")))
+      (is (nil? (re-find apache-20-re "GPL-2.0")))
+      (is (nil? (re-find apache-20-re "fooApache-2.0")))
+      (is (nil? (re-find apache-20-re "Apache-2.0bar")))
+      (is (nil? (re-find apache-20-re "fooApache-2.0bar")))
+      (is (nil? (re-find apache-20-re "foo;Apache-2.0bar")))
+      (is (nil? (re-find apache-20-re "fooApache-2.0;bar"))))
+    (testing "re-seq"
+      (is (= 0 (count (re-seq apache-20-re ""))))
+      (is (= 0 (count (re-seq apache-20-re "foobar"))))
+      (is (= 1 (count (re-seq apache-20-re "Apache-2.0"))))
+      (is (= 2 (count (re-seq apache-20-re "Apache-2.0 Apache-2.0"))))
+      (is (= 2 (count (re-seq apache-20-re "foo;Apache-2.0 bar Apache-2.0 blah"))))))
+  (let [apache-20-or-license-ref-re (build-re ["Apache-2.0"] {:match-license-refs? true})]
+    (testing "matches"
+      (is (not (nil? (re-matches apache-20-or-license-ref-re "Apache-2.0"))))
+      (is (not (nil? (re-matches apache-20-or-license-ref-re "LicenseRef-foo-bar")))))
+    (testing "finds"
+      (is (not (nil? (re-find apache-20-or-license-ref-re "Apache-2.0 LicenseRef-foo-bar"))))
+      (is (not (nil? (re-find apache-20-or-license-ref-re "LicenseRef-foo-bar Apache-2.0"))))
+      (is (not (nil? (re-find apache-20-or-license-ref-re "foo Apache-2.0 bar LicenseRef-foo-bar blah"))))
+      (is (not (nil? (re-find apache-20-or-license-ref-re "foo LicenseRef-foo-bar bar Apache-2.0 blah")))))
+    (testing "re-seq"
+      (is (= 0 (count (re-seq apache-20-or-license-ref-re ""))))
+      (is (= 0 (count (re-seq apache-20-or-license-ref-re "foobar"))))
+      (is (= 1 (count (re-seq apache-20-or-license-ref-re "Apache-2.0"))))
+      (is (= 2 (count (re-seq apache-20-or-license-ref-re "Apache-2.0 LicenseRef-foo-bar "))))
+      (is (= 3 (count (re-seq apache-20-or-license-ref-re "foo;Apache-2.0 bar LicenseRef-foo-bar Apache-2.0 blah")))))
+    (testing "Named capturing groups (via rencg library)"
+      (let [m (rencg/re-matches-ncg apache-20-or-license-ref-re "Apache-2.0")]
+        (is (contains? m "Identifier"))
+        (is (not (contains? m "DocumentRef")))
+        (is (not (contains? m "LicenseRef")))
+        (is (= "Apache-2.0" (get m "Identifier"))))
+      (let [m (rencg/re-matches-ncg apache-20-or-license-ref-re "LicenseRef-foo-bar")]
+        (is (contains? m "Identifier"))
+        (is (contains? m "LicenseRef"))
+        (is (not (contains? m "DocumentRef")))
+        (is (= "LicenseRef-foo-bar" (get m "Identifier")))
+        (is (= "foo-bar"            (get m "LicenseRef"))))
+      (let [m (rencg/re-matches-ncg apache-20-or-license-ref-re "DocumentRef-foo:LicenseRef-bar")]
+        (is (contains? m "Identifier"))
+        (is (contains? m "LicenseRef"))
+        (is (contains? m "DocumentRef"))
+        (is (= "DocumentRef-foo:LicenseRef-bar" (get m "Identifier")))
+        (is (= "bar"                            (get m "LicenseRef")))
+        (is (= "foo"                            (get m "DocumentRef")))))))
+
+; We keep these short as most variations are exercised via build-re-test
+(deftest ids-re-tests
+  (testing "Basic tests"
+    (is (not (nil? (ids-re))))
+    (is (instance? java.util.regex.Pattern (ids-re)))
+    (is (= (ids-re) (ids-re))))  ; Ensure regex is cached
+  (testing "matches"
+    (is (not (nil? (re-matches (ids-re) "Apache-2.0"))))
+    (is (not (nil? (re-matches (ids-re) "MIT"))))
+    (is (not (nil? (re-matches (ids-re) "GPL-2.0"))))                  ; Deprecated id
+    (is (not (nil? (re-matches (ids-re) "LicenseRef-foo"))))
+    (is (not (nil? (re-matches (ids-re) "DocumentRef-foo:LicenseRef-bar"))))
+    (is (not (nil? (re-matches (ids-re) "Classpath-exception-2.0"))))
+    (is (not (nil? (re-matches (ids-re) "AdditionRef-foo"))))
+    (is (not (nil? (re-matches (ids-re) "DocumentRef-foo:AdditionRef-bar")))))
+  (testing "non-matches"
+    (is (nil? (re-matches (ids-re) "Apache-200")))
+    (is (nil? (re-matches (ids-re) " Apache-2.0 ")))
+    (is (nil? (re-matches (ids-re) "Apache-2.0 GPL-2.0")))
+    (is (nil? (re-matches (ids-re) "foobar"))))
+  (testing "finds"
+    (is (not (nil? (re-find (ids-re) "Apache-2.0"))))
+    (is (not (nil? (re-find (ids-re) " Apache-2.0 "))))
+    (is (not (nil? (re-find (ids-re) "Apache-1.1 Apache-2.0 GPL-2.0")))))
+  (testing "re-seq"
+    (is (= 0 (count (re-seq (ids-re) ""))))
+    (is (= 0 (count (re-seq (ids-re) "foobar"))))
+    (is (= 1 (count (re-seq (ids-re) "MIT"))))
+    (is (= 2 (count (re-seq (ids-re) "foo MIT bar X11 blah"))))
+    (is (= 4 (count (re-seq (ids-re) "foo;Apache-2.0 bar DocumentRef-foo:LicenseRef-bar Beerware blah DocumentRef-foo:AdditionRef-bar blahblah"))))))
+
+; We keep these short as most variations are exercised via build-re-test
+(deftest license-ids-re-tests
+  (testing "Basic tests"
+    (is (not (nil? (license-ids-re))))
+    (is (instance? java.util.regex.Pattern (license-ids-re)))
+    (is (= (license-ids-re) (license-ids-re))))  ; Ensure regex is cached
+  (testing "matches"
+    (is (not (nil? (re-matches (license-ids-re) "Apache-2.0"))))
+    (is (not (nil? (re-matches (license-ids-re) "MIT"))))
+    (is (not (nil? (re-matches (license-ids-re) "GPL-2.0"))))
+    (is (not (nil? (re-matches (license-ids-re) "LicenseRef-foo"))))
+    (is (not (nil? (re-matches (license-ids-re) "DocumentRef-foo:LicenseRef-bar")))))
+  (testing "non-matches"
+    (is (nil? (re-matches (license-ids-re) "Apache-200")))
+    (is (nil? (re-matches (license-ids-re) " Apache-2.0 ")))
+    (is (nil? (re-matches (license-ids-re) "Apache-2.0 GPL-2.0")))
+    (is (nil? (re-matches (license-ids-re) "foobar")))
+    (is (nil? (re-matches (license-ids-re) "Classpath-exception-2.0")))
+    (is (nil? (re-matches (license-ids-re) "AdditionRef-foo")))
+    (is (nil? (re-matches (license-ids-re) "DocumentRef-foo:AdditionRef-bar")))))
+
+; We keep these short as most variations are exercised via build-re-test
+(deftest exception-ids-re-tests
+  (testing "Basic tests"
+    (is (not (nil? (exception-ids-re))))
+    (is (instance? java.util.regex.Pattern (exception-ids-re)))
+    (is (= (exception-ids-re) (exception-ids-re))))  ; Ensure regex is cached
+  (testing "matches"
+    (is (not (nil? (re-matches (exception-ids-re) "Classpath-exception-2.0"))))
+    (is (not (nil? (re-matches (exception-ids-re) "Autoconf-exception-3.0"))))
+    (is (not (nil? (re-matches (exception-ids-re) "AdditionRef-foo"))))
+    (is (not (nil? (re-matches (exception-ids-re) "DocumentRef-foo:AdditionRef-bar")))))
+  (testing "non-matches"
+    (is (nil? (re-matches (exception-ids-re) "Classpath-exception-200")))
+    (is (nil? (re-matches (exception-ids-re) " Classpath-exception-2.0 ")))
+    (is (nil? (re-matches (exception-ids-re) "Classpath-exception-2.0 Autoconf-exception-3.0")))
+    (is (nil? (re-matches (exception-ids-re) "foobar")))
+    (is (nil? (re-matches (exception-ids-re) "Apache-2.0")))
+    (is (nil? (re-matches (exception-ids-re) "MIT")))
+    (is (nil? (re-matches (exception-ids-re) "GPL-2.0")))
+    (is (nil? (re-matches (exception-ids-re) "LicenseRef-foo")))
+    (is (nil? (re-matches (exception-ids-re) "DocumentRef-foo:LicenseRef-bar")))))
+
+(deftest license-ref-re-tests
+  (testing "Basic tests"
+    (is (not (nil? (license-ref-re))))
+    (is (instance? java.util.regex.Pattern (license-ref-re)))
+    (is (= (license-ref-re) (license-ref-re))))  ; Ensure regex is cached
+  (testing "matches"
+    (is (not (nil? (re-matches (license-ref-re) "LicenseRef-foo"))))
+    (is (not (nil? (re-matches (license-ref-re) "DocumentRef-foo:LicenseRef-bar")))))
+  (testing "non-matches"
+    (is (nil? (re-matches (license-ref-re) "LicenseRef-@%$^")))
+    (is (nil? (re-matches (license-ref-re) "Apache-2.0")))
+    (is (nil? (re-matches (license-ref-re) "Apache-200")))
+    (is (nil? (re-matches (license-ref-re) " Apache-2.0 ")))
+    (is (nil? (re-matches (license-ref-re) "Apache-2.0 GPL-2.0")))
+    (is (nil? (re-matches (license-ref-re) "foobar")))
+    (is (nil? (re-matches (license-ref-re) "Classpath-exception-2.0")))
+    (is (nil? (re-matches (license-ref-re) "AdditionRef-foo")))
+    (is (nil? (re-matches (license-ref-re) "DocumentRef-foo:AdditionRef-bar")))))
+
+(deftest addition-ref-re-tests
+  (testing "Basic tests"
+    (is (not (nil? (addition-ref-re))))
+    (is (instance? java.util.regex.Pattern (addition-ref-re)))
+    (is (= (addition-ref-re) (addition-ref-re))))  ; Ensure regex is cached
+  (testing "matches"
+    (is (not (nil? (re-matches (addition-ref-re) "AdditionRef-foo"))))
+    (is (not (nil? (re-matches (addition-ref-re) "DocumentRef-foo:AdditionRef-bar"))))))
+  (testing "non-matches"
+    (is (nil? (re-matches (addition-ref-re) "AdditionRef-@%$^")))
+    (is (nil? (re-matches (addition-ref-re) "Apache-2.0")))
+    (is (nil? (re-matches (addition-ref-re) "Apache-200")))
+    (is (nil? (re-matches (addition-ref-re) " Apache-2.0 ")))
+    (is (nil? (re-matches (addition-ref-re) "Apache-2.0 GPL-2.0")))
+    (is (nil? (re-matches (addition-ref-re) "foobar")))
+    (is (nil? (re-matches (addition-ref-re) "Classpath-exception-2.0")))
+    (is (nil? (re-matches (addition-ref-re) "LicenseRef-foo")))
+    (is (nil? (re-matches (addition-ref-re) "DocumentRef-foo:LicenseRef-bar"))))

--- a/test/spdx/regexes_test.clj
+++ b/test/spdx/regexes_test.clj
@@ -120,7 +120,12 @@
     (is (= 0 (count (re-seq (ids-re) "foobar"))))
     (is (= 1 (count (re-seq (ids-re) "MIT"))))
     (is (= 2 (count (re-seq (ids-re) "foo MIT bar X11 blah"))))
-    (is (= 4 (count (re-seq (ids-re) "foo;Apache-2.0 bar DocumentRef-foo:LicenseRef-bar Beerware blah DocumentRef-foo:AdditionRef-bar blahblah"))))))
+    (is (= 4 (count (re-seq (ids-re) "foo;Apache-2.0 bar DocumentRef-foo:LicenseRef-bar Beerware blah DocumentRef-foo:AdditionRef-bar blahblah")))))
+  (testing "Matches for identifiers that are supersets of other identifiers"
+    (let [m (rencg/re-matches-ncg (ids-re) "GPL-2.0-or-later")]
+      (is (= "GPL-2.0-or-later" (get m "Identifier"))))
+    (let [m (rencg/re-matches-ncg (ids-re) "CC-BY-3.0-AU")]
+      (is (= "CC-BY-3.0-AU" (get m "Identifier"))))))
 
 ; We keep these short as most variations are exercised via build-re-test
 (deftest license-ids-re-tests


### PR DESCRIPTION
Addresses issue #46

Summary of changes:

* Add spdx.regexes namespace, containing a "builder" fn and some (hopefully) common formulations that can be pre-cached
