### PR TITLE
Addresses issue 50

### DIFF
--- a/src/spdx/expressions.clj
+++ b/src/spdx/expressions.clj
@@ -356,6 +356,9 @@
     e.g. `aPAcHe-2.0` -> `Apache-2.0`
   * The parser always removes redundant grouping
     e.g. `(((((Apache-2.0))))))` -> `Apache-2.0`
+  * The parser always corrects nonsensical combinations of GNU family
+    license identifiers with the 'or later' marker
+    e.g. `GPL-3.0-only+` -> `GPL-3.0-or-later`
   * The parser synthesises grouping when needed to make SPDX license
     expressions' precedence rules explicit (see [the relevant section within
     annex D of the SPDX specification](https://spdx.github.io/spdx-spec/v3.0/annexes/SPDX-license-expressions/#d45-order-of-precedence-and-parentheses)

--- a/src/spdx/expressions.clj
+++ b/src/spdx/expressions.clj
@@ -11,11 +11,12 @@
 (ns spdx.expressions
   "SPDX license expression functionality. This functionality is bespoke (it does
   not use the parser in `Spdx-Java-Library`)."
-  (:require [clojure.string  :as s]
-            [clojure.set     :as set]
-            [instaparse.core :as insta]
-            [spdx.licenses   :as lic]
-            [spdx.exceptions :as exc]))
+  (:require [clojure.string         :as s]
+            [instaparse.core        :as insta]
+            [spdx.licenses          :as lic]
+            [spdx.exceptions        :as exc]
+            [spdx.impl.regexes      :as ir]
+            [spdx.impl.replacements :as sir]))
 
 (def ^:private case-sensitive-operators-fragment
   "<and>                  = <ws 'AND' ws>
@@ -54,33 +55,8 @@
   or-expression          = and-expression (or and-expression)*
   expression             = ows or-expression ows")
 
-(defn- escape-re
-  "Escapes the given string for use in a regex."
-  [s]
-  (when s
-    (s/escape s {\< "\\<"
-                 \( "\\("
-                 \[ "\\["
-                 \{ "\\{"
-                 \\ "\\\\"
-                 \^ "\\^"
-                 \- "\\-"
-                 \= "\\="
-                 \$ "\\$"
-                 \! "\\!"
-                 \| "\\|"
-                 \] "\\]"
-                 \} "\\}"
-                 \) "\\)"
-                 \? "\\?"
-                 \* "\\*"
-                 \+ "\\+"
-                 \. "\\."
-                 \> "\\>"
-                 })))
-
-(def ^:private license-ids-fragment   (delay (s/join " | " (map #(str "#\"(?i)" (escape-re %) "\"") (filter #(not (s/ends-with? % "+")) (lic/ids))))))  ; Filter out the few deprecated ids that end in "+", since they break the parser)
-(def ^:private exception-ids-fragment (delay (s/join " | " (map #(str "#\"(?i)" (escape-re %) "\"") (exc/ids)))))
+(def ^:private license-ids-fragment   (delay (s/join " | " (map #(str "#\"(?i)" (ir/re-escape %) "\"") (filter #(not (s/ends-with? % "+")) (lic/ids))))))  ; Filter out the few deprecated GNU ids that end in "+", since that's better handled by the grammar
+(def ^:private exception-ids-fragment (delay (s/join " | " (map #(str "#\"(?i)" (ir/re-escape %) "\"") (exc/ids)))))
 
 (def ^:private spdx-license-expression-cs-grammar-d (delay (format spdx-license-expression-grammar-format
                                                                    case-sensitive-operators-fragment
@@ -96,43 +72,6 @@
 
 (def ^:private normalised-spdx-ids-map-d (delay (merge (into {} (map #(vec [(s/lower-case %) %]) (lic/ids)))
                                                        (into {} (map #(vec [(s/lower-case %) %]) (exc/ids))))))
-
-(def ^:private current-gpl-family-ids #{
-                                "AGPL-1.0-only" "AGPL-1.0-or-later" "AGPL-3.0-only" "AGPL-3.0-or-later"
-                                "GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-only" "GPL-3.0-or-later"
-                                "LGPL-2.0-only" "LGPL-2.0-or-later" "LGPL-2.1-only" "LGPL-2.1-or-later" "LGPL-3.0-only" "LGPL-3.0-or-later"})
-
-(def ^:private deprecated-simple-gpl-family-ids {
-                                "AGPL-1.0"  "AGPL-1.0-only"    ; NOTE: not technically a GPL family identifier, since it wasn't published by the FSF, but the same logic works
-                                ; Note: AGPL-1.0+ never existed as a listed SPDX license identifier
-                                "AGPL-3.0"  "AGPL-3.0-only"
-                                ; Note: AGPL-3.0+ never existed as a listed SPDX license identifier
-                                "GPL-1.0"   "GPL-1.0-only"
-                                "GPL-1.0+"  "GPL-1.0-or-later"
-                                "GPL-2.0"   "GPL-2.0-only"
-                                "GPL-2.0+"  "GPL-2.0-or-later"
-                                "GPL-3.0"   "GPL-3.0-only"
-                                "GPL-3.0+"  "GPL-3.0-or-later"
-                                "LGPL-2.0"  "LGPL-2.0-only"
-                                "LGPL-2.0+" "LGPL-2.0-or-later"
-                                "LGPL-2.1"  "LGPL-2.1-only"
-                                "LGPL-2.1+" "LGPL-2.1-or-later"
-                                "LGPL-3.0"  "LGPL-3.0-only"
-                                "LGPL-3.0+" "LGPL-3.0-or-later"})
-
-(def ^:private deprecated-compound-gpl-family-ids {
-                                "GPL-2.0-with-autoconf-exception"  ["GPL-2.0-only" "Autoconf-exception-2.0"]
-                                "GPL-2.0-with-bison-exception"     ["GPL-2.0-only" "Bison-exception-2.2"]
-                                "GPL-2.0-with-classpath-exception" ["GPL-2.0-only" "Classpath-exception-2.0"]
-                                "GPL-2.0-with-font-exception"      ["GPL-2.0-only" "Font-exception-2.0"]
-                                "GPL-2.0-with-GCC-exception"       ["GPL-2.0-only" "GCC-exception-2.0"]
-                                "GPL-3.0-with-autoconf-exception"  ["GPL-3.0-only" "Autoconf-exception-3.0"]
-                                "GPL-3.0-with-GCC-exception"       ["GPL-3.0-only" "GCC-exception-3.1"]})
-
-(def ^:private deprecated-gpl-family-ids (set/union (set (keys deprecated-simple-gpl-family-ids)) (set (keys deprecated-compound-gpl-family-ids))))
-(def ^:private gpl-family-ids            (set/union current-gpl-family-ids deprecated-gpl-family-ids))
-
-(def ^:private not-blank? (complement s/blank?))
 
 (defn- walk-internal
   "Internal implementation of [[walk]]."
@@ -154,8 +93,8 @@
 (defn walk
   "Depth-first walk of `parse-tree` (i.e. obtained from [[parse]]), calling the
   associated functions (or [`clojure.core/identity`](https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/identity)
-  when not provided) for each element in it.  Results are undefined for invalid
-  parse trees.
+  when not provided) for each element in it.  Returns `nil` if `parse-tree` is
+  `nil`.  Results are undefined for invalid parse trees.
 
   Keys in the `fns` map are:
 
@@ -208,80 +147,85 @@
   SPDX expression (a `String`), or `nil` if `parse-tree` is `nil`.  Results
   are undefined for invalid parse trees."
   [parse-tree]
-  (when-let [result (walk {:op-fn      #(s/upper-case (name %))
-                           :license-fn license-map->string
-                           :group-fn   #(when (pos? (count %2))
-                                          (str (when (pos? %1) "(")
-                                               (s/join (str " " (first %2) " ") (rest %2))
-                                               (when (pos? %1) ")")))}
-                          parse-tree)]
-    (s/trim result)))
+  (some-> (walk {:op-fn      #(s/upper-case (name %))
+                 :license-fn license-map->string
+                 :group-fn   #(when (pos? (count %2))
+                                (str (when (pos? %1) "(")
+                                     (s/join (str " " (first %2) " ") (rest %2))
+                                     (when (pos? %1) ")")))}
+                parse-tree)
+          s/trim))
 
 (defn- normalise-nested-operators
-  "Normalises nested operators of the same type."
-  [type coll]
-  (loop [result [type]
+  "Normalises nested operators that are the same."
+  [operator coll]
+  (loop [result [operator]
          f      (first coll)
          r      (rest coll)]
     (if-not f
       (vec result)
       (if (and (sequential? f)
-               (= type (first f)))
+               (= operator (first f)))
         (recur (concat result (rest f)) (first r) (rest r))
         (recur (concat result [f])      (first r) (rest r))))))
 
-(defn- normalise-gpl-id
-  "Normalises a GPL family `license-id` to a tuple (2 element vector) containing
-  the non-deprecated equivalent license id in first position, and (optionally -
-  may be nil) a license-exception-id in second position if `license-id` was a
-  compound id (an id that also identifies an exception, such as
-  \"GPL-2.0-with-classpath-exception\").
+(defn- mandatory-license-id-replacements
+  "Performs mandatory license id replacements on the parse tree (i.e. nonsensical GNU
+  family ids that also contain +)."
+  [parse-tree]
+  (walk {:license-fn (fn [{:keys [license-id or-later?] :as m}]
+                       (if-let [replacement (sir/replacement-for-license-id license-id or-later?)]
+                         (let [result (assoc m :license-id (:license-id replacement))]
+                           (if (:or-later? replacement)
+                             (assoc result  :or-later? true)
+                             (dissoc result :or-later?)))
+                         m))}
+        parse-tree))
 
-  If `license-id` is not deprecated, returns it as-is (in the first position in
-  the tuple)."
-  [license-id]
-  (get deprecated-compound-gpl-family-ids
-       license-id
-       [(get deprecated-simple-gpl-family-ids
-             license-id
-             license-id)
-        nil]))
+(defn- normalise-using-replacements
+  "Normalises a deprecated :license-id entry in a license map, or returns the
+  map unchanged if it doesn't contain a deprecated license id that has a
+  replacement."
+  [{:keys [license-id license-exception-id or-later?] :as m}]
+  (if-let [license-replacement (sir/replacement-for-deprecated-license-id license-id or-later?)]
+    (let [replacement-license-ids   (:license-ids license-replacement)
+          replacement-or-later?     (:or-later?   license-replacement)
+          replacement-exception-id  (:license-exception-id license-replacement)
+          replacement-exception-ids (seq (filter identity [license-exception-id replacement-exception-id]))
+          result                    (mapcat #(if replacement-exception-ids
+                                               (map (fn [replacement-exception-id]
+                                                      (merge {:license-id % :license-exception-id replacement-exception-id}
+                                                             (when replacement-or-later? {:or-later? true})))
+                                                    replacement-exception-ids)
+                                               [(merge {:license-id %} (when replacement-or-later? {:or-later? true}))])
+                                            replacement-license-ids)]
+          (case (count result)
+            0 nil
+            1 (first result)
+            (vec (concat [:and] result))))
+    m))
 
-(defn- normalise-gpl-license-map
-  "Normalises a license map that is known to contain a GPL family `license-id`.
-  This involves:
-  1. Replacing deprecated GPL family license ids with their non-deprecated
-     equivalent
-  2. Turning `:or-later?` flags into the '-or-later' variant of the `license-id`
-  3. Expanding 'compound' license ids (e.g. GPL-2.0-with-classpath-exception)"
-  [{:keys [license-id or-later? license-exception-id]}]
-  (let [[new-license-id new-license-exception-id] (normalise-gpl-id license-id)
-        new-license-id                            (let [or-later-variant (s/replace new-license-id "-only" "-or-later")]
-                                                    (if (and or-later? (lic/listed-id? or-later-variant))
-                                                      or-later-variant
-                                                      new-license-id))]
-    ; Check if we have two license exception ids after expanding the license-id (e.g. from a valid but weird expression such as "GPL-2.0-with-autoconf-exception WITH Classpath-exception-2.0")
-    (if (and (not-blank? license-exception-id)
-             (not-blank? new-license-exception-id)
-             (not= license-exception-id new-license-exception-id))
-      [:and {:license-id new-license-id :license-exception-id new-license-exception-id}
-            {:license-id new-license-id :license-exception-id license-exception-id}]
-      (merge {:license-id new-license-id}
-             (when (not-blank? license-exception-id)     {:license-exception-id license-exception-id})
-             (when (not-blank? new-license-exception-id) {:license-exception-id new-license-exception-id})))))
+(defn- normalise-deprecated-entries-in-license-map
+  "Normalises any deprecated entries in a license map."
+  [{:keys [license-id license-exception-id or-later?] :as m}]
+  ; We perform exception id replacement here, as it's a simple 1:1
+  (let [license-exception-id (or (sir/replacement-for-deprecated-exception-id license-exception-id) license-exception-id)]
+    (if license-id
+      ; It's a listed license
+      (if (and or-later? (or (= license-id "AGPL-1.0") (= license-id "AGPL-3.0")))
+        ; We special case AGPL-1.0+ and AGPL-3.0+, as neither of those are ids
+        (merge {:license-id (str license-id "-or-later")} (when license-exception-id {:license-exception-id license-exception-id}))
+        ; General replacements (provided by spdx.impl.replacements)
+        (normalise-using-replacements (merge m (when license-exception-id {:license-exception-id license-exception-id}))))
+      ; It's a LicenseRef
+      (merge m (when license-exception-id {:license-exception-id license-exception-id})))))
 
 (defn- normalise-deprecated-ids
-  "Normalises deprecated SPDX identifiers, specifically:
-  * GPL family license identifiers
-  * AGPL-1.0 license identifier (which is NOT a GPL identifier, despite the name)
-  * StandardML-NJ license identifier
-  * Nokia-Qt-exception-1.1 license exception identifier"
+  "Normalises deprecated SPDX identifiers, based on the replacements in
+  spdx.impl.replacements."
   [parse-tree]
-  (walk {:license-fn #(cond
-                        (contains? gpl-family-ids (:license-id %))             (normalise-gpl-license-map %)  ; Note: for historical reasons this also handles AGPL-1.0, even though it shouldn't have
-                        (= (:license-id %)           "StandardML-NJ")          (assoc % :license-id "SMLNJ")
-                        (= (:license-exception-id %) "Nokia-Qt-exception-1.1") (assoc % :license-exception-id "Qt-LGPL-exception-1.1")
-                        :else %)}
+  (walk {:license-fn normalise-deprecated-entries-in-license-map
+         :group-fn   (fn [_ [operator & entries]] (normalise-nested-operators operator entries))}
         parse-tree))
 
 (defn- collapse-redundant-clauses
@@ -345,34 +289,35 @@
                       collapse-redundant-clauses? true
                       sort-licenses?              true}}]
    (when-not (s/blank? s)
-     (let [parser (if case-sensitive-operators? @spdx-license-expression-cs-parser-d @spdx-license-expression-ci-parser-d)
-           result (insta/parse parser s)]
-       (if (insta/failure? result)
-         result
-         (let [result (insta/transform {:license-id            #(hash-map  :license-id           (get @normalised-spdx-ids-map-d (s/lower-case (first %&)) (first %&)))
-                                        :license-exception-id  #(hash-map  :license-exception-id (get @normalised-spdx-ids-map-d (s/lower-case (first %&)) (first %&)))
-                                        :license-ref           #(case (count %&)
-                                                                  1 {:license-ref  (first %&)}
-                                                                  2 {:document-ref (first %&) :license-ref (second %&)})
-                                        :addition-ref          #(case (count %&)
-                                                                  1 {:addition-ref  (first %&)}
-                                                                  2 {:addition-document-ref (first %&) :addition-ref (second %&)})
-                                        :license-or-later      #(merge {:or-later? true} (first %&))
-                                        :with-expression       #(merge (first %&)        (second %&))
-                                        :and-expression        #(case (count %&)
-                                                                  1 (first %&)
-                                                                  (normalise-nested-operators :and %&))
-                                        :or-expression         #(case (count %&)
-                                                                  1 (first %&)
-                                                                  (normalise-nested-operators :or %&))
-                                        :expression            #(case (count %&)
-                                                                  1 (first %&)
-                                                                  (vec %&))}
-                                       result)
-               result (if normalise-deprecated-ids?   (normalise-deprecated-ids   result) result)
-               result (if collapse-redundant-clauses? (collapse-redundant-clauses result) result)
-               result (if sort-licenses?              (sort-parse-tree            result) result)]
-           result))))))
+     (let [parser     (if case-sensitive-operators? @spdx-license-expression-cs-parser-d @spdx-license-expression-ci-parser-d)
+           parse-tree (insta/parse parser s)]
+       (if (insta/failure? parse-tree)
+         parse-tree
+         (as-> parse-tree parse-tree
+               (insta/transform {:license-id           #(hash-map  :license-id           (get @normalised-spdx-ids-map-d (s/lower-case (first %&)) (first %&)))
+                                 :license-exception-id #(hash-map  :license-exception-id (get @normalised-spdx-ids-map-d (s/lower-case (first %&)) (first %&)))
+                                 :license-ref          #(case (count %&)
+                                                          1 {:license-ref  (first %&)}
+                                                          2 {:document-ref (first %&) :license-ref (second %&)})
+                                 :addition-ref         #(case (count %&)
+                                                          1 {:addition-ref  (first %&)}
+                                                          2 {:addition-document-ref (first %&) :addition-ref (second %&)})
+                                 :license-or-later     #(merge {:or-later? true} (first %&))
+                                 :with-expression      #(merge (first %&)        (second %&))
+                                 :and-expression       #(case (count %&)
+                                                          1 (first %&)
+                                                          (normalise-nested-operators :and %&))
+                                 :or-expression        #(case (count %&)
+                                                          1 (first %&)
+                                                          (normalise-nested-operators :or %&))
+                                 :expression           #(case (count %&)
+                                                          1 (first %&)
+                                                          (vec %&))}
+                                parse-tree)
+               (mandatory-license-id-replacements parse-tree)
+               (if normalise-deprecated-ids?   (normalise-deprecated-ids   parse-tree) parse-tree)
+               (if collapse-redundant-clauses? (collapse-redundant-clauses parse-tree) parse-tree)
+               (if sort-licenses?              (sort-parse-tree            parse-tree) parse-tree)))))))
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (defn parse
@@ -389,9 +334,8 @@
 
   * `:normalise-deprecated-ids?` (`boolean`, default `true`) - controls whether
     deprecated ids in the expression are normalised to their non-deprecated
-    equivalents (where possible) as part of the parsing process. This applies to
-    the GPL family of license ids, the `AGPL-1.0` and `StandardML-NJ` license
-    ids and the `Nokia-Qt-exception-1.1` license exception id.
+    equivalents (where possible) as part of the parsing process.  Note that not
+    all deprecated identifiers have non-deprecated equivalents.
   * `:case-sensitive-operators?` (`boolean`, default `false`) - controls whether
     operators in expressions (`AND`, `OR`, `WITH`) are case-sensitive
     (spec-compliant, but strict) or not (non-spec-compliant, lenient).

--- a/src/spdx/expressions.clj
+++ b/src/spdx/expressions.clj
@@ -182,10 +182,10 @@
                          m))}
         parse-tree))
 
-(defn- normalise-using-replacements
-  "Normalises a deprecated :license-id entry in a license map, or returns the
-  map unchanged if it doesn't contain a deprecated license id that has a
-  replacement."
+(defn- replace-license-id-in-license-map
+  "Replaces a deprecated :license-id entry in a license map if it has a
+  replacement. Note that this replacement may result in a new nested `:and`
+  clause, since license id replacements aren't always 1:1."
   [{:keys [license-id license-exception-id or-later?] :as m}]
   (if-let [license-replacement (sir/replacement-for-deprecated-license-id license-id or-later?)]
     (let [replacement-license-ids   (:license-ids license-replacement)
@@ -200,31 +200,28 @@
                                                [(merge {:license-id %} (when replacement-or-later? {:or-later? true}))])
                                             replacement-license-ids)]
           (case (count result)
-            0 nil
+            0 nil   ; This should never happen, but just in case we return nil so we don't fall through to the default case and get weird results...
             1 (first result)
             (vec (concat [:and] result))))
     m))
 
-(defn- normalise-deprecated-entries-in-license-map
-  "Normalises any deprecated entries in a license map."
-  [{:keys [license-id license-exception-id or-later?] :as m}]
-  ; We perform exception id replacement here, as it's a simple 1:1
-  (let [license-exception-id (or (sir/replacement-for-deprecated-exception-id license-exception-id) license-exception-id)]
+(defn- replace-deprecated-entries-in-license-map
+  "Replaces any deprecated entries in a license map that have replacements."
+  [{:keys [license-id license-exception-id] :as m}]
+  ; We perform license exception id replacement first, as it's a simple 1:1
+  (let [replacement-exception-id (or (sir/replacement-for-deprecated-exception-id license-exception-id) license-exception-id)
+        result                   (merge m (when replacement-exception-id {:license-exception-id replacement-exception-id}))]
     (if license-id
-      ; It's a listed license
-      (if (and or-later? (or (= license-id "AGPL-1.0") (= license-id "AGPL-3.0")))
-        ; We special case AGPL-1.0+ and AGPL-3.0+, as neither of those are ids
-        (merge {:license-id (str license-id "-or-later")} (when license-exception-id {:license-exception-id license-exception-id}))
-        ; General replacements (provided by spdx.impl.replacements)
-        (normalise-using-replacements (merge m (when license-exception-id {:license-exception-id license-exception-id}))))
-      ; It's a LicenseRef
-      (merge m (when license-exception-id {:license-exception-id license-exception-id})))))
+      ; It's a listed license, so perform license id replacement too
+      (replace-license-id-in-license-map result)
+      ; It's a LicenseRef, so skip license id replacement
+      result)))
 
 (defn- normalise-deprecated-ids
-  "Normalises deprecated SPDX identifiers, based on the replacements in
-  spdx.impl.replacements."
+  "Normalises deprecated SPDX identifiers, based on the replacement rules
+  provided by [[spdx.impl.replacements]]."
   [parse-tree]
-  (walk {:license-fn normalise-deprecated-entries-in-license-map
+  (walk {:license-fn replace-deprecated-entries-in-license-map
          :group-fn   (fn [_ [operator & entries]] (normalise-nested-operators operator entries))}
         parse-tree))
 

--- a/src/spdx/expressions.clj
+++ b/src/spdx/expressions.clj
@@ -225,15 +225,6 @@
          :group-fn   (fn [_ [operator & entries]] (normalise-nested-operators operator entries))}
         parse-tree))
 
-(defn- collapse-redundant-clauses
-  "Collapses redundant clauses in `parse-tree`."
-  [parse-tree]
-  (walk {:group-fn #(let [result (distinct %2)]
-                      (if (= 2 (count result))
-                        (second result)
-                        result))}
-        parse-tree))
-
 (defn- compare-license-maps
   "Compares two license maps, as found in a parse tree."
   [x y]
@@ -255,11 +246,14 @@
   "sort-by comparator for parse-trees"
   [x y]
   (cond
+    ; Keywords (operators) always come first
     (and (keyword? x) (keyword? y))       (compare x y)
     (keyword? x)                          -1
     (keyword? y)                          1
+    ; Then maps (licenses)
     (and (map? x) (map? y))               (compare-license-maps x y)       ; Because compare doesn't support maps
     (map? x)                              -1
+    ; And sequences (sub-clauses) last
     (and (sequential? x) (sequential? y)) (compare-license-sequences x y)  ; Because compare doesn't support maps (which will be elements inside x and y)
     :else                                 1))
 
@@ -269,6 +263,15 @@
   tree as parsing `MIT OR Apache-2.0`."
   [parse-tree]
   (walk {:group-fn #(some-> (seq (sort-by identity parse-tree-compare %2)) vec)}
+        parse-tree))
+
+(defn- collapse-redundant-clauses
+  "Collapses redundant clauses in `parse-tree`."
+  [parse-tree]
+  (walk {:group-fn #(let [result (vec (distinct %2))]
+                      (if (= 2 (count result))
+                        (second result)
+                        result))}
         parse-tree))
 
 (defn parse-with-info
@@ -313,8 +316,10 @@
                                 parse-tree)
                (mandatory-license-id-replacements parse-tree)
                (if normalise-deprecated-ids?   (normalise-deprecated-ids   parse-tree) parse-tree)
+               (if sort-licenses?              (sort-parse-tree            parse-tree) parse-tree)
                (if collapse-redundant-clauses? (collapse-redundant-clauses parse-tree) parse-tree)
-               (if sort-licenses?              (sort-parse-tree            parse-tree) parse-tree)))))))
+               (if (and collapse-redundant-clauses?
+                        sort-licenses?)        (sort-parse-tree            parse-tree) parse-tree)))))))  ; Post-sort, to ensure results of collapsing redundant clauses get sorted
 
 #_{:clj-kondo/ignore [:unused-binding]}
 (defn parse
@@ -338,7 +343,8 @@
     (spec-compliant, but strict) or not (non-spec-compliant, lenient).
   * `:collapse-redundant-clauses?` (`boolean`, default `true`) - controls
     whether redundant clauses (e.g. \"Apache-2.0 AND Apache-2.0\") are
-    collapsed during parsing.
+    collapsed during parsing.  Note: disabled sorting (`:sort-licenses?`) may
+    cause redundant clauses to remain in the parse tree.
   * `:sort-licenses?` (`boolean`, default `true`) - controls whether licenses
     that appear at the same level in the parse tree are sorted alphabetically.
     This means that some parse trees will be identical for different (though

--- a/src/spdx/impl/regexes.clj
+++ b/src/spdx/impl/regexes.clj
@@ -9,8 +9,8 @@
 ;
 
 (ns spdx.impl.regexes
-  "Regex related functionality.  This functionality is bespoke (it does not use
-  any logic from `Spdx-Java-Library`)."
+  "Regex utility namespace. Note: this namespace is not part of the public
+  API of clj-spdx and may change without notice."
   (:require [clojure.string :as s]))
 
 (defn re-escape

--- a/src/spdx/impl/replacements.clj
+++ b/src/spdx/impl/replacements.clj
@@ -1,0 +1,159 @@
+;
+; Copyright © 2024 Peter Monks
+;
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at https://mozilla.org/MPL/2.0/.
+;
+; SPDX-License-Identifier: MPL-2.0
+;
+
+(ns spdx.impl.replacements
+  "Functionality related to replacing certain ids with equivalents. Note: this
+  namespace is not part of the public API of clj-spdx and may change without
+  notice.")
+
+; Note: last cross referenced against license list v3.25.0
+
+(def ^:private mandatory-license-id-replacements-d (delay {
+  "AGPL-1.0-only+"     "AGPL-1.0-or-later"
+  "AGPL-1.0-or-later+" "AGPL-1.0-or-later"
+  "AGPL-3.0-only+"     "AGPL-3.0-or-later"
+  "AGPL-3.0-or-later+" "AGPL-3.0-or-later"
+  "GPL-1.0-only+"      "GPL-1.0-or-later"
+  "GPL-1.0-or-later+"  "GPL-1.0-or-later"
+  "GPL-2.0-only+"      "GPL-2.0-or-later"
+  "GPL-2.0-or-later+"  "GPL-2.0-or-later"
+  "GPL-3.0-only+"      "GPL-3.0-or-later"
+  "GPL-3.0-or-later+"  "GPL-3.0-or-later"
+  "LGPL-2.0-only+"     "LGPL-2.0-or-later"
+  "LGPL-2.0-or-later+" "LGPL-2.0-or-later"
+  "LGPL-2.1-only+"     "LGPL-2.1-or-later"
+  "LGPL-2.1-or-later+" "LGPL-2.1-or-later"
+  "LGPL-3.0-only+"     "LGPL-3.0-or-later"
+  "LGPL-3.0-or-later+" "LGPL-3.0-or-later"}))
+
+(defn replacement-for-license-id
+  "Returns a map representing the replacement of `license-id` & `or-later?`, if
+  any.  Returns `nil` if `license-id` is `nil`, or if there is no replacement.
+
+  The map may contain any combination of these keys:
+
+  * `:license-id` - a replacement SPDX license id
+  * `:or-later?` - the or-later? flag, which may not be the same as the value
+    passed in, depending on what's found
+
+  Notes:
+
+  * `license-id` _must_ be correctly cased as per the SPDX license list"
+  [^String license-id or-later?]
+  (when license-id
+    ; Try looking up with or-later? flag
+    (if-let [new-license-id (get @mandatory-license-id-replacements-d (str license-id (when or-later? "+")))]
+      {:license-id new-license-id}
+      ; Then try looking up without or-later? flag
+      (when-let [new-license-id (get @mandatory-license-id-replacements-d license-id)]
+        (merge {:license-id new-license-id}
+               (when or-later? {:or-later? true}))))))  ; Make sure we preserve the or-later? flag in this case
+
+(def ^:private deprecated-license-id-replacements-d (delay {
+  "AGPL-1.0"                          {:license-ids ["AGPL-1.0-only"]}
+  ; Note: AGPL-1.0+ never existed as a listed SPDX license identifier
+  "AGPL-3.0"                          {:license-ids ["AGPL-3.0-only"]}
+  ; Note: AGPL-3.0+ never existed as a listed SPDX license identifier
+  "GPL-1.0"                           {:license-ids ["GPL-1.0-only"]}
+  "GPL-1.0+"                          {:license-ids ["GPL-1.0-or-later"]}
+  "GPL-2.0"                           {:license-ids ["GPL-2.0-only"]}
+  "GPL-2.0+"                          {:license-ids ["GPL-2.0-or-later"]}
+  "GPL-3.0"                           {:license-ids ["GPL-3.0-only"]}
+  "GPL-3.0+"                          {:license-ids ["GPL-3.0-or-later"]}
+  "LGPL-2.0"                          {:license-ids ["LGPL-2.0-only"]}
+  "LGPL-2.0+"                         {:license-ids ["LGPL-2.0-or-later"]}
+  "LGPL-2.1"                          {:license-ids ["LGPL-2.1-only"]}
+  "LGPL-2.1+"                         {:license-ids ["LGPL-2.1-or-later"]}
+  "LGPL-3.0"                          {:license-ids ["LGPL-3.0-only"]}
+  "LGPL-3.0+"                         {:license-ids ["LGPL-3.0-or-later"]}
+  "GPL-2.0-with-autoconf-exception"   {:license-ids ["GPL-2.0-only"]     :license-exception-id "Autoconf-exception-2.0"}
+  "GPL-2.0-with-autoconf-exception+"  {:license-ids ["GPL-2.0-or-later"] :license-exception-id "Autoconf-exception-2.0"}
+  "GPL-2.0-with-bison-exception"      {:license-ids ["GPL-2.0-only"]     :license-exception-id "Bison-exception-2.2"}
+  "GPL-2.0-with-bison-exception+"     {:license-ids ["GPL-2.0-or-later"] :license-exception-id "Bison-exception-2.2"}
+  "GPL-2.0-with-classpath-exception"  {:license-ids ["GPL-2.0-only"]     :license-exception-id "Classpath-exception-2.0"}
+  "GPL-2.0-with-classpath-exception+" {:license-ids ["GPL-2.0-or-later"] :license-exception-id "Classpath-exception-2.0"}
+  "GPL-2.0-with-font-exception"       {:license-ids ["GPL-2.0-only"]     :license-exception-id "Font-exception-2.0"}
+  "GPL-2.0-with-font-exception+"      {:license-ids ["GPL-2.0-or-later"] :license-exception-id "Font-exception-2.0"}
+  "GPL-2.0-with-GCC-exception"        {:license-ids ["GPL-2.0-only"]     :license-exception-id "GCC-exception-2.0"}
+  "GPL-2.0-with-GCC-exception+"       {:license-ids ["GPL-2.0-or-later"] :license-exception-id "GCC-exception-2.0"}
+  "GPL-3.0-with-autoconf-exception"   {:license-ids ["GPL-3.0-only"]     :license-exception-id "Autoconf-exception-3.0"}
+  "GPL-3.0-with-autoconf-exception+"  {:license-ids ["GPL-3.0-or-later"] :license-exception-id "Autoconf-exception-3.0"}
+  "GPL-3.0-with-GCC-exception"        {:license-ids ["GPL-3.0-only"]     :license-exception-id "GCC-exception-3.1"}
+  "GPL-3.0-with-GCC-exception+"       {:license-ids ["GPL-3.0-or-later"] :license-exception-id "GCC-exception-3.1"}
+  "StandardML-NJ"                     {:license-ids ["SMLNJ"]}
+  "BSD-2-Clause-FreeBSD"              {:license-ids ["BSD-2-Clause-Views"]}
+  "BSD-2-Clause-NetBSD"               {:license-ids ["BSD-2-Clause"]}
+  "bzip2-1.0.5"                       {:license-ids ["bzip2-1.0.6"]}
+  "Net-SNMP"                          {:license-ids ["BSD-3-Clause" "MIT-CMU"]}                                               ; Grab bag of multiple licenses
+  "eCos-2.0"                          {:license-ids ["GPL-2.0-only"]     :license-exception-id "eCos-exception-2.0"}          ; Changed from license to GPL-2.0 exception
+  "eCos-2.0+"                         {:license-ids ["GPL-2.0-or-later"] :license-exception-id "eCos-exception-2.0"}          ; Changed from license to GPL-2.0 exception
+  "wxWindows"                         {:license-ids ["GPL-2.0-only"]     :license-exception-id "WxWindows-exception-3.1"}     ; Changed from license to GPL-2.0 exception
+  "wxWindows+"                        {:license-ids ["GPL-2.0-or-later"] :license-exception-id "WxWindows-exception-3.1"}}))  ; Changed from license to GPL-2.0 exception
+
+(defn replacement-for-deprecated-license-id
+  "Returns a map representing the replacement of `license-id` & `or-later?`, if
+  any.  Returns `nil` if `license-id` is `nil`, or if there is no replacement
+  (including the case where it's not deprecated).
+
+  The map may contain any combination of these keys:
+
+  * `:license-ids` - a sequence of replacement SPDX license ids
+  * `:license-exception-id` - a single replacement SPDX license
+     exception id
+  * `:or-later?` - the or-later? flag, which may not be the same as the value
+    passed in, depending on what's found
+
+  Notes:
+
+  * `license-id` _must_ be correctly cased as per the SPDX license list
+  * Some deprecated SPDX license ids have been replaced with multiple
+    license ids - in these cases this should be considered an `AND`
+  * Not all deprecated `license-id`s have a replacement.
+  * if or-later? is true, the or-later variant is first looked up, and then, if
+    no result is found, the 'naked' identifier is also looked up"
+  [^String license-id or-later?]
+  (when license-id
+    (if or-later?
+      ; First try looking up with or-later? flag
+      (if-let [result (get @deprecated-license-id-replacements-d (str license-id "+"))]
+        result
+        ; Then try looking up without or-later? flag
+        (when-let [result (get @deprecated-license-id-replacements-d license-id)]
+          (assoc result :or-later? true)))  ; Make sure we preserve the or-later? flag in this case
+      ; or-later? flag was false - look up without it
+      (get @deprecated-license-id-replacements-d license-id))))
+
+(def ^:private deprecated-exception-id-replacements-d (delay {
+  "Nokia-Qt-exception-1.1" "Qt-LGPL-exception-1.1"}))
+
+(defn replacement-for-deprecated-exception-id
+  "Returns the SPDX exception id that supercedes `exception-id`, if any.
+  Returns `nil` if `exception-id` was `nil`, or if there is no replacement for
+  `exception-id` (including the case where it's not deprecated).
+
+  Notes:
+
+  * `exception-id` _must_ be correctly cased as per the SPDX license exception
+    list
+  * Not all deprecated `exception-id`s have a replacement."
+  [^String exception-id]
+  (when exception-id
+    (get @deprecated-exception-id-replacements-d exception-id)))
+
+(defn init!
+  "Initialises this namespace upon first call (and does nothing on subsequent
+  calls), returning `nil`. Consumers of this namespace are not required to call
+  this fn, as initialisation will occur implicitly anyway; it is provided to
+  allow explicit control of the cost of initialisation to callers who need it."
+  []
+  @mandatory-license-id-replacements-d
+  @deprecated-license-id-replacements-d
+  @deprecated-exception-id-replacements-d
+  nil)

--- a/src/spdx/impl/replacements.clj
+++ b/src/spdx/impl/replacements.clj
@@ -58,9 +58,9 @@
 
 (def ^:private deprecated-license-id-replacements-d (delay {
   "AGPL-1.0"                          {:license-ids ["AGPL-1.0-only"]}
-  ; Note: AGPL-1.0+ never existed as a listed SPDX license identifier
+  "AGPL-1.0+"                         {:license-ids ["AGPL-1.0-or-later"]}    ; Note: AGPL-1.0+ never existed as a listed SPDX license identifier, but we still (optionally) replace it
   "AGPL-3.0"                          {:license-ids ["AGPL-3.0-only"]}
-  ; Note: AGPL-3.0+ never existed as a listed SPDX license identifier
+  "AGPL-3.0+"                         {:license-ids ["AGPL-3.0-or-later"]}    ; Note: AGPL-3.0+ never existed as a listed SPDX license identifier, but we still (optionally) replace it
   "GPL-1.0"                           {:license-ids ["GPL-1.0-only"]}
   "GPL-1.0+"                          {:license-ids ["GPL-1.0-or-later"]}
   "GPL-2.0"                           {:license-ids ["GPL-2.0-only"]}

--- a/test/spdx/expressions_test.clj
+++ b/test/spdx/expressions_test.clj
@@ -235,6 +235,7 @@
     (is (= (parse "Apache-2.0 AND Apache-2.0 OR MIT")         [:or {:license-id "Apache-2.0"} {:license-id "MIT"}]))
     (is (= (parse "Apache-2.0 OR MIT OR Apache-2.0")          [:or {:license-id "Apache-2.0"} {:license-id "MIT"}]))
     (is (= (parse "Apache-2.0 AND MIT AND Apache-2.0")        [:and {:license-id "Apache-2.0"} {:license-id "MIT"}]))
+    (is (= (parse "(Apache-2.0 OR MIT) AND (MIT OR Apache-2.0)") [:or {:license-id "Apache-2.0"} {:license-id "MIT"}]))
     (is (= (parse "Apache-2.0 AND Apache-2.0 OR Apache-2.0 AND Apache-2.0")
                                                               {:license-id "Apache-2.0"}))
     (is (= (parse "Apache-2.0 AND (Apache-2.0 OR (Apache-2.0 AND Apache-2.0))")

--- a/test/spdx/expressions_test.clj
+++ b/test/spdx/expressions_test.clj
@@ -122,13 +122,84 @@
                                                                {:license-id "GPL-2.0-only"}
                                                                {:license-id "MIT"}
                                                                {:license-id "Unlicense"}])))
-  (testing "Expressions that exercise GPL identifier normalisation"
-    (is (= (parse "AGPL-1.0-or-later")                        {:license-id "AGPL-1.0-or-later"}))
-    (is (= (parse "AGPL-1.0+")                                {:license-id "AGPL-1.0-or-later"}))
+  (testing "Expressions that exercise license id replacement (deprecated and/or weirdo GNU family replacements)"
+    ; 1:1 replacements
+    (is (= (parse "AGPL-1.0")                                 {:license-id "AGPL-1.0-only"}))
+    (is (= (parse "AGPL-1.0+")                                {:license-id "AGPL-1.0-or-later"}))   ; Note: AGPL-1.0+ is not a listed identifier - it's an expression, but still needs to be replaced
+    (is (= (parse "AGPL-3.0")                                 {:license-id "AGPL-3.0-only"}))
+    (is (= (parse "AGPL-3.0+")                                {:license-id "AGPL-3.0-or-later"}))   ; Note: AGPL-3.0+ is not a listed identifier - it's an expression, but still needs to be replaced
+    (is (= (parse "GPL-1.0")                                  {:license-id "GPL-1.0-only"}))
+    (is (= (parse "GPL-1.0+")                                 {:license-id "GPL-1.0-or-later"}))
+    (is (= (parse "GPL-2.0")                                  {:license-id "GPL-2.0-only"}))
     (is (= (parse "GPL-2.0+")                                 {:license-id "GPL-2.0-or-later"}))
+    (is (= (parse "GPL-3.0")                                  {:license-id "GPL-3.0-only"}))
+    (is (= (parse "LGPL-2.0" )                                {:license-id "LGPL-2.0-only"}))
+    (is (= (parse "LGPL-2.0+")                                {:license-id "LGPL-2.0-or-later"}))
+    (is (= (parse "LGPL-2.1" )                                {:license-id "LGPL-2.1-only"}))
+    (is (= (parse "LGPL-2.1+")                                {:license-id "LGPL-2.1-or-later"}))
+    (is (= (parse "LGPL-3.0" )                                {:license-id "LGPL-3.0-only"}))
+    (is (= (parse "LGPL-3.0+")                                {:license-id "LGPL-3.0-or-later"}))
+    (is (= (parse "StandardML-NJ")                            {:license-id "SMLNJ"}))
+    (is (= (parse "StandardML-NJ+")                           {:license-id "SMLNJ" :or-later? true}))   ; Note: StandardML-NJ+ is not a listed identifier - it's an expression, but still needs to be replaced, preserving the or-later? flag
+    (is (= (parse "BSD-2-Clause-FreeBSD")                     {:license-id "BSD-2-Clause-Views"}))
+    (is (= (parse "BSD-2-Clause-NetBSD")                      {:license-id "BSD-2-Clause"}))
+    (is (= (parse "bzip2-1.0.5")                              {:license-id "bzip2-1.0.6"}))
+    (is (= (parse "LGPL-2.1-only WITH Nokia-Qt-exception-1.1") {:license-id "LGPL-2.1-only" :license-exception-id "Qt-LGPL-exception-1.1"}))
+    (is (= (parse "LicenseRef-foo WITH Nokia-Qt-exception-1.1") {:license-ref "foo" :license-exception-id "Qt-LGPL-exception-1.1"}))
+    ; 1:2 replacements
+    (is (= (parse "Net-SNMP")                                 [:and
+                                                               {:license-id "BSD-3-Clause"}
+                                                               {:license-id "MIT-CMU"}]))
+    (is (= (parse "Net-SNMP+")                                [:and    ; Nonsensical, but confirms that the or-later? flag is preserved
+                                                               {:license-id "BSD-3-Clause" :or-later? true}
+                                                               {:license-id "MIT-CMU"      :or-later? true}]))
+    ; Cursed expressions with +
     (is (= (parse "GPL-2.0-only+")                            {:license-id "GPL-2.0-or-later"}))
     (is (= (parse "GPL-2.0-or-later+")                        {:license-id "GPL-2.0-or-later"}))
-    ; These next couple are pretty cursed...
+    (is (= (parse "GPL-2.0-only+" {:normalise-deprecated-ids? false})   ; This should always be normalised, regardless of deprecation normalisation
+                                                              {:license-id "GPL-2.0-or-later"}))
+    (is (= (parse "GPL-2.0-or-later+" {:normalise-deprecated-ids? false})   ; This should always be normalised, regardless of deprecation normalisation
+                                                              {:license-id "GPL-2.0-or-later"}))
+    ; Cursed eCos-2.0 and wxWindows cases (these two changed type - license ids replaced by exception ids 😬)
+    (is (= (parse "eCos-2.0")                                 {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"}))
+    (is (= (parse "eCos-2.0+")                                {:license-id "GPL-2.0-or-later" :license-exception-id "eCos-exception-2.0"}))
+    (is (= (parse "eCos-2.0 OR Apache-2.0")                   [:or  {:license-id "Apache-2.0"} {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 AND Apache-2.0 AND MIT")          [:and {:license-id "Apache-2.0"} {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"} {:license-id "MIT"}]))
+    (is (= (parse "Apache-2.0 AND eCos-2.0")                  [:and {:license-id "Apache-2.0"} {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 AND Apache-2.0")                  [:and {:license-id "Apache-2.0"} {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0+ AND Apache-2.0")                 [:and {:license-id "Apache-2.0"} {:license-id "GPL-2.0-or-later" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 AND (Apache-2.0)")                [:and {:license-id "Apache-2.0"} {:license-id "GPL-2.0-only"     :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "GPL-2.0-only WITH Classpath-exception-2.0 AND eCos-2.0")
+                                                              [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "Classpath-exception-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "GPL-2.0-with-classpath-exception AND eCos-2.0")
+                                                              [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "Classpath-exception-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 WITH Classpath-exception-2.0")    [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "Classpath-exception-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 WITH eCos-exception-2.0")         {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}))
+    (is (= (parse "MIT AND eCos-2.0" {:normalise-deprecated-ids? false})
+                                                              [:and
+                                                               {:license-id "MIT"}
+                                                               {:license-id "eCos-2.0"}]))
+    (is (= (parse "wxWindows")                                {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"}))
+    (is (= (parse "MIT AND wxWindows")                        [:and {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"} {:license-id "MIT"}]))
+    (is (= (parse "wxWindows AND MIT")                        [:and {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"} {:license-id "MIT"}]))
+    (is (= (parse "wxWindows WITH WxWindows-exception-3.1")   {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"}))
+    (is (= (parse "BSD-2-Clause AND wxWindows" {:normalise-deprecated-ids? false})
+                                                              [:and
+                                                               {:license-id "BSD-2-Clause"}
+                                                               {:license-id "wxWindows"}]))
+    (is (= (parse "eCos-2.0 AND wxWindows")                   [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "wxWindows AND eCos-2.0")                   [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "WxWindows-exception-3.1"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    ; Cursed "double license exception" cases
     (is (= (parse "GPL-2.0-with-classpath-exception WITH Classpath-exception-2.0")
                                                               {:license-id "GPL-2.0-only" :license-exception-id "Classpath-exception-2.0"}))
     (is (= (parse "GPL-2.0-with-GCC-exception WITH Classpath-exception-2.0")
@@ -138,7 +209,20 @@
     (is (= (parse "GPL-2.0-with-GCC-exception+ WITH Classpath-exception-2.0")
                                                               [:and
                                                                {:license-id "GPL-2.0-or-later" :license-exception-id "Classpath-exception-2.0"}
-                                                               {:license-id "GPL-2.0-or-later" :license-exception-id "GCC-exception-2.0"}])))
+                                                               {:license-id "GPL-2.0-or-later" :license-exception-id "GCC-exception-2.0"}]))
+    (is (= (parse "Net-SNMP WITH Classpath-exception-2.0")    [:and
+                                                               {:license-id "BSD-3-Clause" :license-exception-id "Classpath-exception-2.0"}
+                                                               {:license-id "MIT-CMU"      :license-exception-id "Classpath-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 WITH GCC-exception-2.0 AND Apache-2.0")
+                                                              [:and
+                                                               {:license-id "Apache-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "GCC-exception-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}]))
+    (is (= (parse "eCos-2.0 WITH GCC-exception-2.0 AND MIT WITH WxWindows-exception-3.1")
+                                                              [:and
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "GCC-exception-2.0"}
+                                                               {:license-id "GPL-2.0-only" :license-exception-id "eCos-exception-2.0"}
+                                                               {:license-id "MIT" :license-exception-id "WxWindows-exception-3.1"}])))
   (testing "Expressions that exercise collapsing redundant clauses"
     (is (= (parse "Apache-2.0 OR Apache-2.0")                 {:license-id "Apache-2.0"}))
     (is (= (parse "Apache-2.0 AND Apache-2.0" {:collapse-redundant-clauses? true})
@@ -185,7 +269,7 @@
     (is (= (parse "GPL-2.0+" {:normalise-deprecated-ids? false})
            {:license-id "GPL-2.0" :or-later? true}))
     (is (= (parse "GPL-2.0-only+" {:normalise-deprecated-ids? false})
-           {:license-id "GPL-2.0-only" :or-later? true}))
+           {:license-id "GPL-2.0-or-later"}))  ; This is a mandatory replacement, not controllable via the :normalise-deprecated-ids? flag
     (is (= (parse "Apache-2.0 OR GPL-2.0" {:normalise-deprecated-ids? false})
            [:or {:license-id "Apache-2.0"} {:license-id "GPL-2.0"}]))
     (is (= (parse "Apache-2.0 OR GPL-2.0+" {:normalise-deprecated-ids? false})

--- a/test/spdx/test_utils.clj
+++ b/test/spdx/test_utils.clj
@@ -31,6 +31,7 @@
 
   Throws on exceptions."
   [url]
-  (url/input-stream url {:follow-redirects?     true
-                         :retry-when-throttled? true
-                         :request-headers       {"User-Agent" "https://github.com/pmonks/clj-spdx"}}))
+  (url/input-stream url {:follow-redirects?                   true
+                         :retry-when-throttled?               true
+                         :return-cached-content-on-exception? true
+                         :request-headers                     {"User-Agent" "https://github.com/pmonks/clj-spdx"}}))


### PR DESCRIPTION
Addresses issue #50

Summary of changes:

* Adds a dedicated namespace for handling all known replacements
* Makes replacement (mostly) generic / data driven, to cover all the known combinations of replacement (1:1, 1:M, change-in-type-of-id)
* Adds separate concepts for mandatory replacements vs optional "deprecated id upgrade" replacements
* Refactors existing code to use the new namespace's facilities